### PR TITLE
Implement panorama shared namespace access #29

### DIFF
--- a/pandevice/panorama.py
+++ b/pandevice/panorama.py
@@ -92,7 +92,6 @@ class SharedDeviceGroup(DeviceGroup):
     XPATH = "/config/shared"
     ROOT = None
     SUFFIX = None
-    NAME = "shared"
 
     def xpath(self):
         """Overide to allow special access to the shared namespace.
@@ -145,6 +144,7 @@ class Panorama(base.PanDevice):
         # create a shared device group instance
         self.shared = SharedDeviceGroup()
         self.shared.parent = self
+        self.shared.name = 'Shared'
 
     def refresh(self, running_config=False, refresh_children=True, exceptions=True, xml=None):
         """Overide to also refresh the SharedDeviceGroup instance


### PR DESCRIPTION
This is a first pass at adding support for shared objects in panorama. Basically I have added a new attribute called `shared` to `panorama.Panorama` that instantiates an instance of the new `panorama. SharedDeviceGroup` class. This new class inherits from `panorama.DeviceGroup` but simply overrides the xpath functionality to allow direct access to `/config/shared`. Also `panorama.Panorama` now implements `refresh()` directly to refresh the SharedDeviceGroup instance transparently along with the normal panorama refresh. 