### PR TITLE
Fixes PaloAltoNetworks/pandevice#39 - adds support for DHCP settings on various data interfaces

### DIFF
--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -661,6 +661,9 @@ class Layer3Subinterface(Subinterface):
         comment (str): The interface's comment
         ipv4_mss_adjust(int): TCP MSS adjustment for ipv4
         ipv6_mss_adjust(int): TCP MSS adjustment for ipv6
+        enable_dhcp (bool): Enable DHCP on this interface
+        create_dhcp_default_route (bool): Create default route pointing to default gateway provided by server
+        dhcp_default_route_metric (int): Metric for the DHCP default route
 
     """
     DEFAULT_MODE = 'layer3'
@@ -713,6 +716,14 @@ class Layer3Subinterface(Subinterface):
         params[-1].add_profile(
             '7.1.0',
             path='adjust-tcp-mss/ipv6-mss-adjustment', vartype='int')
+        params.append(VersionedParamPath(
+            'enable_dhcp', path='dhcp-client/enable', vartype='yesno'))
+        params.append(VersionedParamPath(
+            'create_dhcp_default_route',
+            path='dhcp-client/create-default-route', vartype='yesno'))
+        params.append(VersionedParamPath(
+            'dhcp_default_route_metric',
+            path='dhcp-client/default-route-metric', vartype='int'))
 
         self._params = tuple(params)
 
@@ -826,6 +837,9 @@ class EthernetInterface(PhysicalInterface):
         comment (str): The interface's comment
         ipv4_mss_adjust(int): TCP MSS adjustment for ipv4
         ipv6_mss_adjust(int): TCP MSS adjustment for ipv6
+        enable_dhcp (bool): Enable DHCP on this interface
+        create_dhcp_default_route (bool): Create default route pointing to default gateway provided by server
+        dhcp_default_route_metric (int): Metric for the DHCP default route
 
     """
     ALLOW_SET_VLAN = True
@@ -911,6 +925,17 @@ class EthernetInterface(PhysicalInterface):
             '7.1.0',
             path='{mode}/adjust-tcp-mss/ipv6-mss-adjustment',
             vartype='int', condition={'mode': 'layer3'})
+        params.append(VersionedParamPath(
+            'enable_dhcp', path='{mode}/dhcp-client/enable',
+            vartype='yesno', condition={'mode': 'layer3'}))
+        params.append(VersionedParamPath(
+            'create_dhcp_default_route',
+            path='{mode}/dhcp-client/create-default-route',
+            vartype='yesno', condition={'mode': 'layer3'}))
+        params.append(VersionedParamPath(
+            'dhcp_default_route_metric',
+            path='{mode}/dhcp-client/default-route-metric',
+            vartype='int', condition={'mode': 'layer3'}))
 
         self._params = tuple(params)
 
@@ -1026,6 +1051,9 @@ class VlanInterface(Interface):
         comment (str): The interface's comment
         ipv4_mss_adjust(int): TCP MSS adjustment for ipv4
         ipv6_mss_adjust(int): TCP MSS adjustment for ipv6
+        enable_dhcp (bool): Enable DHCP on this interface
+        create_dhcp_default_route (bool): Create default route pointing to default gateway provided by server
+        dhcp_default_route_metric (int): Metric for the DHCP default route
 
     """
     CHILDTYPES = (
@@ -1072,6 +1100,14 @@ class VlanInterface(Interface):
         params[-1].add_profile(
             '7.1.0',
             path='adjust-tcp-mss/ipv6-mss-adjustment', vartype='int')
+        params.append(VersionedParamPath(
+            'enable_dhcp', path='dhcp-client/enable', vartype='yesno'))
+        params.append(VersionedParamPath(
+            'create_dhcp_default_route',
+            path='dhcp-client/create-default-route', vartype='yesno'))
+        params.append(VersionedParamPath(
+            'dhcp_default_route_metric',
+            path='dhcp-client/default-route-metric', vartype='int'))
 
         self._params = tuple(params)
 

--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -970,6 +970,9 @@ class AggregateInterface(PhysicalInterface):
         comment (str): The interface's comment
         ipv4_mss_adjust(int): TCP MSS adjustment for ipv4
         ipv6_mss_adjust(int): TCP MSS adjustment for ipv6
+        enable_dhcp (bool): Enable DHCP on this interface
+        create_dhcp_default_route (bool): Create default route pointing to default gateway provided by server
+        dhcp_default_route_metric (int): Metric for the DHCP default route
 
     """
     ALLOW_SET_VLAN = True
@@ -1034,6 +1037,17 @@ class AggregateInterface(PhysicalInterface):
         params[-1].add_profile(
             '7.1.0',
             path='adjust-tcp-mss/ipv6-mss-adjustment', vartype='int')
+        params.append(VersionedParamPath(
+            'enable_dhcp', path='{mode}/dhcp-client/enable',
+            vartype='yesno', condition={'mode': 'layer3'}))
+        params.append(VersionedParamPath(
+            'create_dhcp_default_route',
+            path='{mode}/dhcp-client/create-default-route',
+            vartype='yesno', condition={'mode': 'layer3'}))
+        params.append(VersionedParamPath(
+            'dhcp_default_route_metric',
+            path='{mode}/dhcp-client/default-route-metric',
+            vartype='int', condition={'mode': 'layer3'}))
 
         self._params = tuple(params)
 


### PR DESCRIPTION
Tested with 6.1, 7.1, 8.0 EthernetInterface and Layer3Subinterface.  Verified against xml for other interfaces.