### PR TITLE
Fixes PaloAltoNetworks/pandevice#60 - Allow objects to change their xpath based on the parent

### DIFF
--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -1514,7 +1514,7 @@ class ParentAwareXpath(object):
     def __init__(self):
         self.settings = {}
 
-    def add_profile(self, version=None, value=None, *parents):
+    def add_profile(self, version=None, value=None, parents=None):
         """Adds support for the given versions, specific to the parents.
 
         If no parents are specified, then a parent of ``None`` is assumed,
@@ -1525,11 +1525,11 @@ class ParentAwareXpath(object):
         Args:
             version (str): The version number (default: '0.0.0').
             value (str): The xpath setting.
-            parents (str): The parent classes this version/value is valid for.
+            parents (list/tuple): The parent classes this version/value is valid for.
 
         """
-        if not parents:
-            parents = [None, ]
+        if parents is None:
+            parents = (None, )
 
         for p in parents:
             self.settings.setdefault(p, VersioningSupport())

--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -201,8 +201,8 @@ class IPv6Address(VersionedPanObject):
         self._xpaths.add_profile(value='/ipv6/address')
         # Mode interface xpaths (mode: layer3)
         self._xpaths.add_profile(
-            None, '/layer3/ipv6/address',
-            'EthernetInterface', 'AggregateInterface')
+            value='/layer3/ipv6/address',
+            parents=('EthernetInterface', 'AggregateInterface'))
 
         # params
         params = []
@@ -470,8 +470,8 @@ class Arp(VersionedPanObject):
         self._xpaths.add_profile(value='/layer3/arp')
         # Subinterface xpaths
         self._xpaths.add_profile(
-            None, '/arp',
-            'Layer3Subinterface')
+            value='/arp',
+            parents=('Layer3Subinterface', ))
 
         # params
         params = []
@@ -1246,6 +1246,20 @@ class TunnelInterface(Interface):
 
 
 class StaticRoute(VersionedPanObject):
+    """Static Route
+
+    Add to a :class:`pandevice.network.VirtualRouter` instance.
+
+    Args:
+        name (str): The name
+        destination (str): Destination network
+        nexthop_type (str): ip-address or discard
+        nexthop (str): Next hop IP address
+        interface (str): Next hop interface
+        admin_dist (str): Administrative distance
+        metric (int): Metric (Default: 10)
+
+    """
     SUFFIX = ENTRY
 
     def _setup_xpaths(self):
@@ -1280,11 +1294,12 @@ class StaticRouteV6(StaticRoute):
     Add to a :class:`pandevice.network.VirtualRouter` instance.
 
     Args:
+        name (str): The name
         destination (str): Destination network
         nexthop_type (str): ip-address or discard
         nexthop (str): Next hop IP address
         interface (str): Next hop interface
-        admin-dist (str): Administrative distance
+        admin_dist (str): Administrative distance
         metric (int): Metric (Default: 10)
 
     """

--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -192,13 +192,17 @@ class IPv6Address(VersionedPanObject):
         auto_config_flag (bool):
 
     """
-    XPATH = "/ipv6/address"
     SUFFIX = ENTRY
     NAME = "address"
 
     def _setup(self):
         # xpaths
+        # Non-mode interface xpaths
         self._xpaths.add_profile(value='/ipv6/address')
+        # Mode interface xpaths (mode: layer3)
+        self._xpaths.add_profile(
+            None, '/layer3/ipv6/address',
+            'EthernetInterface', 'AggregateInterface')
 
         # params
         params = []
@@ -446,14 +450,15 @@ class Interface(VsysOperations):
         self.delete()
 
 
-class SubinterfaceArp(VersionedPanObject):
+class Arp(VersionedPanObject):
     """Static ARP Mapping
 
-    Can be added to subinterfaces in 'layer3' mode
+    Can be added to various interfaces.
 
     Args:
         ip (str): The IP address
         hw_address (str): The MAC address for the static ARP
+        interface (str): The interface (when attached to VlanInterface only)
 
     """
     SUFFIX = ENTRY
@@ -461,32 +466,22 @@ class SubinterfaceArp(VersionedPanObject):
 
     def _setup(self):
         # xpaths
-        self._xpaths.add_profile(value='/arp')
+        # Interface xpaths
+        self._xpaths.add_profile(value='/layer3/arp')
+        # Subinterface xpaths
+        self._xpaths.add_profile(
+            None, '/arp',
+            'Layer3Subinterface')
 
         # params
         params = []
 
         params.append(VersionedParamPath(
             'hw_address', path='hw-address'))
+        params.append(VersionedParamPath(
+            'interface', path='interface'))
 
         self._params = tuple(params)
-
-
-class EthernetInterfaceArp(SubinterfaceArp):
-    """Static ARP Mapping
-
-    Can be added to interfaces in 'layer3' mode
-
-    Args:
-        ip (str): The IP address
-        hw_address (str): The MAC address for the static ARP
-
-    """
-    def _setup(self):
-        super(EthernetInterfaceArp, self)._setup()
-
-        # xpaths
-        self._xpaths.add_profile(value='/layer3/arp')
 
 
 class VirtualWire(VersionedPanObject):
@@ -669,7 +664,7 @@ class Layer3Subinterface(Subinterface):
     DEFAULT_MODE = 'layer3'
     CHILDTYPES = (
         "network.IPv6Address",
-        "network.SubinterfaceArp",
+        "network.Arp",
         "network.ManagementProfile",
     )
 
@@ -847,7 +842,7 @@ class EthernetInterface(PhysicalInterface):
         "network.Layer3Subinterface",
         "network.Layer2Subinterface",
         "network.IPv6Address",
-        "network.EthernetInterfaceArp",
+        "network.Arp",
         "network.ManagementProfile",
     )
 
@@ -980,7 +975,7 @@ class AggregateInterface(PhysicalInterface):
         "network.Layer3Subinterface",
         "network.Layer2Subinterface",
         "network.IPv6Address",
-        "network.EthernetInterfaceArp",
+        "network.Arp",
         "network.ManagementProfile",
     )
 
@@ -1072,7 +1067,7 @@ class VlanInterface(Interface):
     """
     CHILDTYPES = (
         "network.IPv6Address",
-        "network.EthernetInterfaceArp",
+        "network.Arp",
         "network.ManagementProfile",
     )
 
@@ -1143,7 +1138,6 @@ class LoopbackInterface(Interface):
     """
     CHILDTYPES = (
         "network.IPv6Address",
-        "network.EthernetInterfaceArp",
         "network.ManagementProfile",
     )
 
@@ -1206,7 +1200,6 @@ class TunnelInterface(Interface):
     """
     CHILDTYPES = (
         "network.IPv6Address",
-        "network.EthernetInterfaceArp",
         "network.ManagementProfile",
     )
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1208,3 +1208,75 @@ class TestParamPath(unittest.TestCase):
 
         for elm in elms:
             self.assertTrue(elm.text in settings['baz'])
+
+class ParentClass1(object):
+    pass
+
+class ParentClass2(object):
+    pass
+
+class UnassociatedParent(object):
+    pass
+
+class TestParentAwareXpath(unittest.TestCase):
+    DEFAULT_PATH_1 = '/default/path/1'
+    DEFAULT_PATH_2 = '/default/path/2'
+    SPECIFIED_PATH_1 = '/some/specific/path/1'
+    SPECIFIED_PATH_2 = '/some/specific/path/2'
+
+    def setUp(self):
+        self.obj = Base.ParentAwareXpath()
+        self.obj.add_profile(value=self.DEFAULT_PATH_1)
+        self.obj.add_profile('1.0.0', self.DEFAULT_PATH_2)
+        self.obj.add_profile(None, self.SPECIFIED_PATH_1,
+                             'ParentClass1', 'ParentClass2')
+        self.obj.add_profile('2.0.0', self.SPECIFIED_PATH_2,
+                             'ParentClass1', 'ParentClass2')
+
+    def test_old_default_xpath(self):
+        parent = UnassociatedParent()
+
+        self.assertEqual(
+            self.DEFAULT_PATH_1,
+            self.obj._get_versioned_value(
+                (0, 5, 0), parent))
+
+    def test_new_default_xpath(self):
+        parent = UnassociatedParent()
+
+        self.assertEqual(
+            self.DEFAULT_PATH_2,
+            self.obj._get_versioned_value(
+                (1, 0, 0), parent))
+
+    def test_old_specefied_xpath_for_class1(self):
+        parent = ParentClass1()
+
+        self.assertEqual(
+            self.SPECIFIED_PATH_1,
+            self.obj._get_versioned_value(
+                (0, 5, 0), parent))
+
+    def test_new_specefied_xpath_for_class1(self):
+        parent = ParentClass1()
+
+        self.assertEqual(
+            self.SPECIFIED_PATH_2,
+            self.obj._get_versioned_value(
+                (2, 0, 0), parent))
+
+    def test_old_specefied_xpath_for_class2(self):
+        parent = ParentClass2()
+
+        self.assertEqual(
+            self.SPECIFIED_PATH_1,
+            self.obj._get_versioned_value(
+                (0, 0, 0), parent))
+
+    def test_new_specefied_xpath_for_class2(self):
+        parent = ParentClass2()
+
+        self.assertEqual(
+            self.SPECIFIED_PATH_2,
+            self.obj._get_versioned_value(
+                (5, 0, 0), parent))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1228,10 +1228,10 @@ class TestParentAwareXpath(unittest.TestCase):
         self.obj = Base.ParentAwareXpath()
         self.obj.add_profile(value=self.DEFAULT_PATH_1)
         self.obj.add_profile('1.0.0', self.DEFAULT_PATH_2)
-        self.obj.add_profile(None, self.SPECIFIED_PATH_1,
-                             'ParentClass1', 'ParentClass2')
+        self.obj.add_profile(value=self.SPECIFIED_PATH_1,
+                             parents=('ParentClass1', 'ParentClass2'))
         self.obj.add_profile('2.0.0', self.SPECIFIED_PATH_2,
-                             'ParentClass1', 'ParentClass2')
+                             ('ParentClass1', 'ParentClass2'))
 
     def test_old_default_xpath(self):
         parent = UnassociatedParent()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -13,7 +13,6 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import mock
-import sys
 import unittest
 import uuid
 import xml.etree.ElementTree as ET

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -215,8 +215,7 @@ class TestElementStr_7_0(unittest.TestCase):
             '</hw-address></entry></arp></entry></units></layer3></entry>',
         ])
 
-        ao = pandevice.network.SubinterfaceArp('10.5.10.15',
-                                               '00:30:48:52:cd:dc')
+        ao = pandevice.network.Arp('10.5.10.15', '00:30:48:52:cd:dc')
         l3so = pandevice.network.Layer3Subinterface(
             'ethernet1/1.355', 355, '10.20.30.40/24',
             mtu=1500, adjust_tcp_mss=True)
@@ -458,7 +457,7 @@ class TestXpaths_7_0(unittest.TestCase):
             "/arp/entry[@name='arp object']",
         ])
 
-        ao = pandevice.network.SubinterfaceArp('arp object')
+        ao = pandevice.network.Arp('arp object')
         l3so = pandevice.network.Layer3Subinterface('Layer3 Subint Object')
         eio = pandevice.network.EthernetInterface('Eth Interface Object')
         fw = pandevice.firewall.Firewall('fw')
@@ -480,7 +479,7 @@ class TestXpaths_7_0(unittest.TestCase):
             "/arp",
         ])
 
-        ao = pandevice.network.SubinterfaceArp('arp object')
+        ao = pandevice.network.Arp('arp object')
         l3so = pandevice.network.Layer3Subinterface('Layer3 Subint Object')
         eio = pandevice.network.EthernetInterface('Eth Interface Object')
         fw = pandevice.firewall.Firewall('fw')


### PR DESCRIPTION
also collapses Arp class, removes Arp from tunnels and loopback interfaces, and adds some tests