### PR TITLE
Fixes PaloAltoNetworks/pandevice#38 and more

### DIFF
--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -2407,7 +2407,7 @@ class ParamPath(object):
                 in the XML.
 
         """
-        if not self.path and self.vartype != 'exist':
+        if not self.path:
             # No path, so this is just a parameter ParamPath
             return
 

--- a/pandevice/device.py
+++ b/pandevice/device.py
@@ -256,6 +256,8 @@ class Administrator(VersionedPanObject):
 
     Args:
         name (str): Admin name
+        authentication_profile (str): The authentication profile
+        web_client_cert_only (bool): Use only client certificate authentication (Web)
         superuser (bool): Admin type - superuser
         superuser_read_only (bool): Admin type - superuser, read only
         panorama_admin (bool): Panonrama - a panorama admin only
@@ -265,6 +267,8 @@ class Administrator(VersionedPanObject):
         vsys_device (str): The device specification for the vsys admin (default: localhost.localdomain)
         vsys_read_only (list/str): Physical firewalls: the vsys this read only admin should manage
         vsys_read_only_device (str): The device specification for the vsys_read_only admin (default: localhost.localdomain)
+        ssh_public_key (str): Use Public Key Authentication (SSH)
+        role_profile (str): The role based profile
         password_hash (encrypted str): The encrypted password
         password_profile (str): The password profile for this user
 
@@ -279,6 +283,11 @@ class Administrator(VersionedPanObject):
         # params
         params = []
 
+        params.append(VersionedParamPath(
+            'authentication_profile', path='authentication-profile'))
+        params.append(VersionedParamPath(
+            'web_client_cert_only', vartype='yesno',
+            path='client-certificate-only'))
         params.append(VersionedParamPath(
             'superuser', vartype='yesno',
             path='permissions/role-based/superuser'))
@@ -309,6 +318,10 @@ class Administrator(VersionedPanObject):
             'vsys_read_only_device', exclude=True, vartype='entry',
             path='permissions/role-based/vsysreader',
             default='localhost.localdomain'))
+        params.append(VersionedParamPath(
+            'ssh_public_key', path='public-key'))
+        params.append(VersionedParamPath(
+            'role_profile', path='permissions/role-based/custom/profile'))
         params.append(VersionedParamPath(
             'password_hash', path='phash', vartype='encrypted'))
         params.append(VersionedParamPath(

--- a/pandevice/device.py
+++ b/pandevice/device.py
@@ -263,9 +263,9 @@ class Administrator(VersionedPanObject):
         device_admin_read_only (bool): Admin type - device admin, read only
         vsys (list/str): Physical firewalls: the vsys this admin should manage
         vsys_device (str): The device specification for the vsys admin (default: localhost.localdomain)
-        password_hash (encrypted str): The encrypted password
         vsys_read_only (list/str): Physical firewalls: the vsys this read only admin should manage
         vsys_read_only_device (str): The device specification for the vsys_read_only admin (default: localhost.localdomain)
+        password_hash (encrypted str): The encrypted password
         password_profile (str): The password profile for this user
 
     """

--- a/pandevice/device.py
+++ b/pandevice/device.py
@@ -264,9 +264,7 @@ class Administrator(VersionedPanObject):
         device_admin (bool): Admin type - device admin
         device_admin_read_only (bool): Admin type - device admin, read only
         vsys (list/str): Physical firewalls: the vsys this admin should manage
-        vsys_device (str): The device specification for the vsys admin (default: localhost.localdomain)
         vsys_read_only (list/str): Physical firewalls: the vsys this read only admin should manage
-        vsys_read_only_device (str): The device specification for the vsys_read_only admin (default: localhost.localdomain)
         ssh_public_key (str): Use Public Key Authentication (SSH)
         role_profile (str): The role based profile
         password_hash (encrypted str): The encrypted password
@@ -307,17 +305,9 @@ class Administrator(VersionedPanObject):
             'vsys', vartype='member',
             path='permissions/role-based/vsysadmin/entry vsys_device/vsys'))
         params.append(VersionedParamPath(
-            'vsys_device', exclude=True, vartype='entry',
-            path='permissions/role-based/vsysadmin',
-            default='localhost.localdomain'))
-        params.append(VersionedParamPath(
             'vsys_read_only', vartype='member',
             path='permissions/role-based/vsysreader' +
                  '/entry vsys_read_only_device/vsys'))
-        params.append(VersionedParamPath(
-            'vsys_read_only_device', exclude=True, vartype='entry',
-            path='permissions/role-based/vsysreader',
-            default='localhost.localdomain'))
         params.append(VersionedParamPath(
             'ssh_public_key', path='public-key'))
         params.append(VersionedParamPath(
@@ -326,6 +316,14 @@ class Administrator(VersionedPanObject):
             'password_hash', path='phash', vartype='encrypted'))
         params.append(VersionedParamPath(
             'password_profile', path='password-profile'))
+        params.append(VersionedParamPath(
+            'vsys_device', exclude=True, vartype='entry',
+            path='permissions/role-based/vsysadmin',
+            default='localhost.localdomain'))
+        params.append(VersionedParamPath(
+            'vsys_read_only_device', exclude=True, vartype='entry',
+            path='permissions/role-based/vsysreader',
+            default='localhost.localdomain'))
 
         self._params = tuple(params)
 

--- a/pandevice/device.py
+++ b/pandevice/device.py
@@ -296,11 +296,11 @@ class Administrator(VersionedPanObject):
             'panorama_admin', vartype='yesno',
             path='permissions/role-based/panorama-admin'))
         params.append(VersionedParamPath(
-            'device_admin', vartype='exist', exist_tag='deviceadmin',
-            path='permissions/role-based'))
+            'device_admin', vartype='exist',
+            path='permissions/role-based/deviceadmin'))
         params.append(VersionedParamPath(
             'device_admin_read_only', vartype='exist',
-            exist_tag='devicereader', path='permissions/role-based'))
+            path='permissions/role-based/devicereader'))
         params.append(VersionedParamPath(
             'vsys', vartype='member',
             path='permissions/role-based/vsysadmin/entry vsys_device/vsys'))
@@ -336,5 +336,6 @@ class Administrator(VersionedPanObject):
             new_password (str): The new password for this user.
 
         """
-        self.password_hash = self.request_password_hash(new_password)
+        dev = self.nearest_pandevice()
+        self.password_hash = dev.request_password_hash(new_password)
         self.update('password_hash')

--- a/pandevice/firewall.py
+++ b/pandevice/firewall.py
@@ -63,6 +63,8 @@ class Firewall(PanDevice):
         "device.Vsys",
         "device.VsysResources",
         "device.SystemSettings",
+        "device.PasswordProfile",
+        "device.Administrator",
         "ha.HighAvailability",
         "objects.AddressObject",
         "objects.AddressGroup",

--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -211,9 +211,9 @@ class IPv6Address(VersionedPanObject):
             'enable_on_interface', vartype='yesno',
             path='enable-on-interface'))
         params.append(VersionedParamPath(
-            'prefix', vartype='exist', path='prefix'))
+            'prefix', vartype='exist', path='', exist_tag='prefix'))
         params.append(VersionedParamPath(
-            'anycast', vartype='exist', path='anycast'))
+            'anycast', vartype='exist', path='', exist_tag='anycast'))
         params.append(VersionedParamPath(
             'advertise_enabled', vartype='yesno',
             path='advertise/enable'))
@@ -1191,11 +1191,8 @@ class TunnelInterface(Interface):
         ipv6_enabled (bool): IPv6 Enabled (requires IPv6Address child object)
         management_profile (ManagementProfile): Interface Management Profile
         mtu(int): MTU for interface
-        adjust_tcp_mss (bool): Adjust TCP MSS
         netflow_profile (NetflowProfile): Netflow profile
         comment (str): The interface's comment
-        ipv4_mss_adjust(int): TCP MSS adjustment for ipv4
-        ipv6_mss_adjust(int): TCP MSS adjustment for ipv6
 
     """
     CHILDTYPES = (
@@ -1223,24 +1220,9 @@ class TunnelInterface(Interface):
         params.append(VersionedParamPath(
             'mtu', path='mtu', vartype='int'))
         params.append(VersionedParamPath(
-            'adjust_tcp_mss', path='adjust-tcp-mss', vartype='yesno'))
-        params[-1].add_profile(
-            '7.1.0',
-            vartype='yesno', path='adjust-tcp-mss/enable')
-        params.append(VersionedParamPath(
             'netflow_profile', path='netflow-profile'))
         params.append(VersionedParamPath(
             'comment', path='comment'))
-        params.append(VersionedParamPath(
-            'ipv4_mss_adjust', exclude=True))
-        params[-1].add_profile(
-            '7.1.0',
-            path='adjust-tcp-mss/ipv4-mss-adjustment', vartype='int')
-        params.append(VersionedParamPath(
-            'ipv6_mss_adjust', exclude=True))
-        params[-1].add_profile(
-            '7.1.0',
-            path='adjust-tcp-mss/ipv6-mss-adjustment', vartype='int')
 
         self._params = tuple(params)
 

--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -211,9 +211,9 @@ class IPv6Address(VersionedPanObject):
             'enable_on_interface', vartype='yesno',
             path='enable-on-interface'))
         params.append(VersionedParamPath(
-            'prefix', vartype='exist', path='', exist_tag='prefix'))
+            'prefix', vartype='exist', path='prefix'))
         params.append(VersionedParamPath(
-            'anycast', vartype='exist', path='', exist_tag='anycast'))
+            'anycast', vartype='exist', path='anycast'))
         params.append(VersionedParamPath(
             'advertise_enabled', vartype='yesno',
             path='advertise/enable'))

--- a/pandevice/panorama.py
+++ b/pandevice/panorama.py
@@ -95,8 +95,10 @@ class Panorama(base.PanDevice):
     FIREWALL_CLASS = firewall.Firewall
     NAME = "hostname"
     CHILDTYPES = (
-        "panorama.DeviceGroup",
+        "device.Administrator",
+        "device.PasswordProfile",
         "firewall.Firewall",
+        "panorama.DeviceGroup",
     )
 
     def __init__(self,

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -139,6 +139,27 @@ def pytest_report_header(config):
 
     return ans
 
+# Order tests alphabetically.  This is needed because by default pytest gets
+# the tests of the current class, executes them, then walks the inheritance
+# to get parent tests, which is not what we want.
+def pytest_collection_modifyitems(items):
+    grouping = {}
+    lookup = {}
+    reordered = []
+
+    for x in items:
+        location, tc = x.nodeid.rsplit('::', 1)
+        lookup[(location, tc)] = x
+        grouping.setdefault(location, [])
+        grouping[location].append(tc)
+
+    for location in sorted(grouping.keys()):
+        tests = sorted(grouping[location])
+        for tc in tests:
+            reordered.append(lookup[(location, tc)])
+
+    items[:] = reordered
+
 # Define a state fixture.
 class State(object):
     pass

--- a/tests/live/test_device_config.py
+++ b/tests/live/test_device_config.py
@@ -169,7 +169,7 @@ class TestFirewallAdministrator(testlib.FwFlow):
             fw.hostname, state.obj.uid, 'secret')
         new_fw.refresh_system_info()
 
-    def delete_dependencies(self, fw, state):
+    def cleanup_dependencies(self, fw, state):
         fw.delete_type(device.PasswordProfile)
 
 
@@ -220,5 +220,5 @@ class TestPanoramaAdministrator(testlib.PanoFlow):
             pano.hostname, state.obj.uid, 'secret')
         new_pano.refresh_system_info()
 
-    def delete_dependencies(self, pano, state):
+    def cleanup_dependencies(self, pano, state):
         pano.delete_type(device.PasswordProfile)

--- a/tests/live/test_network.py
+++ b/tests/live/test_network.py
@@ -49,7 +49,7 @@ class TestVlan(testlib.FwFlow):
 # Interface - inherited by other interface objects
 # SubinterfaceArp
 
-class TestEthernetInterfaceArp(testlib.FwFlow):
+class TestArpOnEthernetInterface(testlib.FwFlow):
     def create_dependencies(self, fw, state):
         state.eth_obj = None
         state.eth = testlib.get_available_interfaces(fw)[0]
@@ -60,7 +60,7 @@ class TestEthernetInterfaceArp(testlib.FwFlow):
         state.eth_obj.create()
 
     def setup_state_obj(self, fw, state):
-        state.obj = network.EthernetInterfaceArp(
+        state.obj = network.Arp(
             testlib.random_ip(), '00:30:48:52:ab:cd')
         state.eth_obj.add(state.obj)
 
@@ -68,11 +68,10 @@ class TestEthernetInterfaceArp(testlib.FwFlow):
         state.obj.hw_address = '00:30:48:52:12:9a'
 
     def cleanup_dependencies(self, fw, state):
-        if state.eth_obj is not None:
-            try:
-                state.eth_obj.delete()
-            except Exception:
-                pass
+        try:
+            state.eth_obj.delete()
+        except Exception:
+            pass
 
 class TestVirtualWire(testlib.FwFlow):
     def create_dependencies(self, fw, state):

--- a/tests/live/testlib.py
+++ b/tests/live/testlib.py
@@ -52,10 +52,15 @@ class FwFlow(object):
     def create_dependencies(self, fw, state):
         pass
 
-    def test_02_create(self, fw, state_map):
+    def sanity(self, fw, state_map):
         state = state_map.setdefault(fw)
         if state.err:
             state.fail_func('prereq failed')
+
+        return state
+
+    def test_02_create(self, fw, state_map):
+        state = self.sanity(fw, state_map)
 
         state.fail_func = pytest.xfail
         state.err = True
@@ -67,16 +72,12 @@ class FwFlow(object):
         pass
 
     def test_03_refreshall(self, fw, state_map):
-        state = state_map.setdefault(fw)
-        if state.err:
-            state.fail_func('prereq failed')
+        state = self.sanity(fw, state_map)
 
         state.obj.refreshall(state.obj.parent, add=False)
 
     def test_04_update(self, fw, state_map):
-        state = state_map.setdefault(fw)
-        if state.err:
-            state.fail_func('prereq failed')
+        state = self.sanity(fw, state_map)
 
         self.update_state_obj(fw, state)
         state.obj.apply()
@@ -84,10 +85,8 @@ class FwFlow(object):
     def update_state_obj(self, fw, state):
         pass
 
-    def test_05_delete(self, fw, state_map):
-        state = state_map.setdefault(fw)
-        if state.err:
-            state.fail_func('prereq failed')
+    def test_97_delete(self, fw, state_map):
+        state = self.sanity(fw, state_map)
 
         state.obj.delete()
 
@@ -118,10 +117,15 @@ class DevFlow(object):
     def create_dependencies(self, dev, state):
         pass
 
-    def test_02_create(self, dev, state_map):
+    def sanity(self, dev, state_map):
         state = state_map.setdefault(dev)
         if state.err:
             state.fail_func('prereq failed')
+
+        return state
+
+    def test_02_create(self, dev, state_map):
+        state = self.sanity(dev, state_map)
 
         state.fail_func = pytest.xfail
         state.err = True
@@ -133,16 +137,12 @@ class DevFlow(object):
         pass
 
     def test_03_refreshall(self, dev, state_map):
-        state = state_map.setdefault(dev)
-        if state.err:
-            state.fail_func('prereq failed')
+        state = self.sanity(dev, state_map)
 
         state.obj.refreshall(state.obj.parent, add=False)
 
     def test_04_update(self, dev, state_map):
-        state = state_map.setdefault(dev)
-        if state.err:
-            state.fail_func('prereq failed')
+        state = self.sanity(dev, state_map)
 
         self.update_state_obj(dev, state)
         state.obj.apply()
@@ -150,17 +150,13 @@ class DevFlow(object):
     def update_state_obj(self, dev, state):
         pass
 
-    def test_05_delete(self, dev, state_map):
-        state = state_map.setdefault(dev)
-        if state.err:
-            state.fail_func('prereq failed')
+    def test_97_delete(self, dev, state_map):
+        state = self.sanity(dev, state_map)
 
         state.obj.delete()
 
     def test_98_cleanup_dependencies(self, dev, state_map):
         state = state_map.setdefault(dev)
-        if state.err:
-            state.fail_func('prereq failed')
 
         self.cleanup_dependencies(dev, state)
 
@@ -169,6 +165,7 @@ class DevFlow(object):
 
     def test_99_removeall(self, dev, state_map):
         dev.removeall()
+
 
 class PanoFlow(object):
     def test_01_setup_dependencies(self, pano, state_map):
@@ -186,10 +183,15 @@ class PanoFlow(object):
     def create_dependencies(self, pano, state):
         pass
 
-    def test_02_create(self, pano, state_map):
+    def sanity(self, pano, state_map):
         state = state_map.setdefault(pano)
         if state.err:
             state.fail_func('prereq failed')
+
+        return state
+
+    def test_02_create(self, pano, state_map):
+        state = self.sanity(pano, state_map)
 
         state.fail_func = pytest.xfail
         state.err = True
@@ -201,16 +203,12 @@ class PanoFlow(object):
         pass
 
     def test_03_refreshall(self, pano, state_map):
-        state = state_map.setdefault(pano)
-        if state.err:
-            state.fail_func('prereq failed')
+        state = self.sanity(pano, state_map)
 
         state.obj.refreshall(state.obj.parent, add=False)
 
     def test_04_update(self, pano, state_map):
-        state = state_map.setdefault(pano)
-        if state.err:
-            state.fail_func('prereq failed')
+        state = self.sanity(pano, state_map)
 
         self.update_state_obj(pano, state)
         state.obj.apply()
@@ -218,17 +216,13 @@ class PanoFlow(object):
     def update_state_obj(self, pano, state):
         pass
 
-    def test_05_delete(self, pano, state_map):
-        state = state_map.setdefault(pano)
-        if state.err:
-            state.fail_func('prereq failed')
+    def test_97_delete(self, pano, state_map):
+        state = self.sanity(pano, state_map)
 
         state.obj.delete()
 
     def test_98_cleanup_dependencies(self, pano, state_map):
         state = state_map.setdefault(pano)
-        if state.err:
-            state.fail_func('prereq failed')
 
         self.cleanup_dependencies(pano, state)
 


### PR DESCRIPTION
Fixed parsing ParamPath.vartype == 'exist' in pandevice
ParamPath.vartype == 'exist' now has a mandatory `exist_tag`, updated pre-existing "exist" vartypes (IPv6Address was the only one with vartype='exist')
Added `device.PasswordProfile` and `device.Administrator`
Added `PanObject.request_password_hash()`
Removed invalid params from TunnelInterface, updated docstring
Fixed ordering of test case execution
Added tests for password profiles and administrators
Moved delete tests for the various testlib.Flow classes to 3rd from last
Refactored testlib.Flows a bit, added `sanity()` 
Removed sanity checking on testlib.PanoFlow and testlib.DevFlow from `cleanup_dependencies()`