### PR TITLE
Fixes PaloAltoNetworks/pandevice#56 - add live network tests

### DIFF
--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -114,7 +114,10 @@ class PanObject(object):
         return self.uid
 
     def __repr__(self):
-        return "<%s %s at 0x%x>" % (type(self).__name__, repr(getattr(self, self.NAME, None)), id(self))
+        return '<{0}{1} {2:#x}>'.format(
+            type(self).__name__,
+            ' {0}'.format(self.uid) if self.uid else '',
+            id(self))
 
     @classmethod
     def variables(cls):

--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -148,7 +148,7 @@ class Vlan(VsysOperations):
 
     Args:
         interface (list): List of interface names
-        virtual-interface (VlanInterface): The layer2 vlan interface for this vlan
+        virtual-interface (VlanInterface): The layer3 vlan interface for this vlan
 
     """
     SUFFIX = ENTRY

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -14,6 +14,7 @@ one_panorama_per_version = []
 ha_pairs = []
 panorama_fw_combinations = []
 
+
 def desc(pano=None, fw=None):
     ans = []
     if pano is not None:
@@ -23,6 +24,7 @@ def desc(pano=None, fw=None):
     if fw is not None:
         ans.append('{0}.{1}NGFW'.format(*fw))
     return ''.join(ans)
+
 
 def init():
     '''
@@ -122,6 +124,7 @@ def init():
 # Invoke the init() to set globals for our tests.
 init()
 
+
 def pytest_report_header(config):
     if not one_device_type_per_version:
         ans = [
@@ -138,6 +141,7 @@ def pytest_report_header(config):
             ans.append(' '.join(line))
 
     return ans
+
 
 # Order tests alphabetically.  This is needed because by default pytest gets
 # the tests of the current class, executes them, then walks the inheritance
@@ -160,9 +164,11 @@ def pytest_collection_modifyitems(items):
 
     items[:] = reordered
 
+
 # Define a state fixture.
 class State(object):
     pass
+
 
 class StateMap(object):
     def __init__(self):
@@ -172,9 +178,11 @@ class StateMap(object):
         key = tuple(d.hostname for d in x)
         return self.config.setdefault(key, State())
 
+
 @pytest.fixture(scope='class')
 def state_map(request):
     yield StateMap()
+
 
 # Define parametrized fixtures.
 @pytest.fixture(
@@ -185,6 +193,7 @@ def state_map(request):
 def fw(request):
     return request.param
 
+
 @pytest.fixture(
     scope='session',
     params=[x[0] for x in one_device_type_per_version],
@@ -193,6 +202,7 @@ def fw(request):
 def dev(request):
     return request.param
 
+
 @pytest.fixture(
     scope='session',
     params=[x[0] for x in one_panorama_per_version],
@@ -200,6 +210,7 @@ def dev(request):
 )
 def pano(request):
     return request.param
+
 
 @pytest.fixture(
     scope='session',

--- a/tests/live/test_network.py
+++ b/tests/live/test_network.py
@@ -66,11 +66,17 @@ class TestVlan(testlib.FwFlow):
             state.eth_objs.append(network.EthernetInterface(
                 eth, 'layer2'))
             fw.add(state.eth_objs[-1])
-            state.eth_objs[-1].create()
+        fw.create_type(network.EthernetInterface)
+
+        state.vlan_interface = network.VlanInterface(
+            'vlan.{0}'.format(random.randint(100, 200)))
+        fw.add(state.vlan_interface)
+        state.vlan_interface.create()
 
     def setup_state_obj(self, fw, state):
         state.obj = network.Vlan(
             testlib.random_name(), state.eths[0],
+            state.vlan_interface.uid,
         )
         fw.add(state.obj)
 
@@ -78,11 +84,15 @@ class TestVlan(testlib.FwFlow):
         state.obj.interface = state.eths[1]
 
     def cleanup_dependencies(self, fw, state):
-        for x in state.eth_objs:
-            try:
-                x.delete()
-            except Exception:
-                pass
+        try:
+            state.vlan_interface.delete()
+        except Exception:
+            pass
+
+        try:
+            fw.delete_type(network.EthernetInterface)
+        except Exception:
+            pass
 
 
 class TestIPv6AddressOnEthernetInterface(testlib.FwFlow):

--- a/tests/live/test_network.py
+++ b/tests/live/test_network.py
@@ -15,7 +15,46 @@ class TestZones(testlib.FwFlow):
     def update_state_obj(self, fw, state):
         state.obj.mode = 'layer2'
 
-# StaticMac
+
+class TestStaticMac(testlib.FwFlow):
+    def create_dependencies(self, fw, state):
+        state.parent = None
+        state.eth_objs = []
+
+        state.eths = testlib.get_available_interfaces(fw, 2)
+
+        for eth in state.eths:
+            state.eth_objs.append(network.EthernetInterface(
+                eth, 'layer2'))
+            fw.add(state.eth_objs[-1])
+        fw.create_type(network.EthernetInterface)
+
+        state.parent = network.Vlan(
+            testlib.random_name(), state.eths)
+        fw.add(state.parent)
+        state.parent.create()
+
+    def setup_state_obj(self, fw, state):
+        state.obj = network.StaticMac(
+            testlib.random_mac(),
+            state.eths[0],
+        )
+        state.parent.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.interface = state.eths[1]
+
+    def cleanup_dependencies(self, fw, state):
+        try:
+            fw.delete_type(network.EthernetInterface)
+        except Exception:
+            pass
+
+        try:
+            state.parent.delete()
+        except Exception:
+            pass
+
 
 class TestVlan(testlib.FwFlow):
     def create_dependencies(self, fw, state):
@@ -45,9 +84,76 @@ class TestVlan(testlib.FwFlow):
             except Exception:
                 pass
 
-# IPv6Address
+
+class TestIPv6AddressOnEthernetInterface(testlib.FwFlow):
+    def create_dependencies(self, fw, state):
+        state.parent = None
+        state.eth = testlib.get_available_interfaces(fw)[0]
+
+        state.parent = network.EthernetInterface(
+            state.eth, 'layer3', testlib.random_ip('/24'))
+        fw.add(state.parent)
+        state.parent.create()
+
+    def setup_state_obj(self, fw, state):
+        state.obj = network.IPv6Address(
+            testlib.random_ipv6(),
+            False, True, False, True, 2420000, 604800, True, False)
+        state.parent.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.enable_on_interface = True
+        state.obj.prefix = False
+        state.obj.anycast = True
+
+    def cleanup_dependencies(self, fw, state):
+        try:
+            state.parent.delete()
+        except Exception:
+            pass
+
+
+class TestIPv6AddressOnLayer3Subinterface(testlib.FwFlow):
+    def create_dependencies(self, fw, state):
+        state.eth_obj = None
+        state.eth = testlib.get_available_interfaces(fw)[0]
+
+        state.eth_obj = network.EthernetInterface(
+            state.eth, 'layer3', testlib.random_ip('/24'))
+        fw.add(state.eth_obj)
+        state.eth_obj.create()
+
+        tag = random.randint(1, 4000)
+        state.parent = network.Layer3Subinterface(
+            '{0}.{1}'.format(state.eth, tag),
+            tag, testlib.random_ip('/24'))
+        state.eth_obj.add(state.parent)
+        state.parent.create()
+
+    def setup_state_obj(self, fw, state):
+        state.obj = network.IPv6Address(
+            testlib.random_ipv6(),
+            False, True, False, True, 2420000, 604800, True, False)
+        state.parent.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.enable_on_interface = True
+        state.obj.prefix = False
+        state.obj.anycast = True
+
+    def cleanup_dependencies(self, fw, state):
+        try:
+            state.parent.delete()
+        except Exception:
+            pass
+
+        try:
+            state.eth_obj.delete()
+        except Exception:
+            pass
+
+
 # Interface - inherited by other interface objects
-# SubinterfaceArp
 
 class TestArpOnEthernetInterface(testlib.FwFlow):
     def create_dependencies(self, fw, state):
@@ -72,6 +178,44 @@ class TestArpOnEthernetInterface(testlib.FwFlow):
             state.eth_obj.delete()
         except Exception:
             pass
+
+
+class TestArpOnSubinterface(testlib.FwFlow):
+    def create_dependencies(self, fw, state):
+        state.eth_obj = None
+        state.eth = testlib.get_available_interfaces(fw)[0]
+
+        state.eth_obj = network.EthernetInterface(
+            state.eth, 'layer3', testlib.random_ip('/24'))
+        fw.add(state.eth_obj)
+        state.eth_obj.create()
+
+        tag = random.randint(1, 4000)
+        state.parent = network.Layer3Subinterface(
+            '{0}.{1}'.format(state.eth, tag),
+            tag, testlib.random_ip('/24'))
+        state.eth_obj.add(state.parent)
+        state.parent.create()
+
+    def setup_state_obj(self, fw, state):
+        state.obj = network.Arp(
+            testlib.random_ip(), testlib.random_mac())
+        state.parent.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.hw_address = testlib.random_mac()
+
+    def cleanup_dependencies(self, fw, state):
+        try:
+            state.parent.delete()
+        except Exception:
+            pass
+
+        try:
+            state.eth_obj.delete()
+        except Exception:
+            pass
+
 
 class TestVirtualWire(testlib.FwFlow):
     def create_dependencies(self, fw, state):
@@ -108,6 +252,7 @@ class TestVirtualWire(testlib.FwFlow):
                 x.delete()
             except Exception:
                 pass
+
 
 # Subinterface - inherited by others
 # AbstractSubinterface
@@ -154,6 +299,7 @@ class TestL3Subinterface(testlib.FwFlow):
         except Exception:
             pass
 
+
 class TestL2Subinterface(testlib.FwFlow):
     def create_dependencies(self, fw, state):
         state.eth = None
@@ -182,6 +328,7 @@ class TestL2Subinterface(testlib.FwFlow):
         except Exception:
             pass
 
+
 # PhysicalInterface - inherited by others
 
 class TestL3EthernetInterface(testlib.FwFlow):
@@ -189,14 +336,14 @@ class TestL3EthernetInterface(testlib.FwFlow):
         state.management_profiles = []
 
         state.eth = testlib.get_available_interfaces(fw)[0]
+
         state.management_profiles = [
-            network.ManagementProfile(testlib.random_name(), ping=True,
-                                      ssh=True, https=False)
-            for x in range(2)
-        ]
+            network.ManagementProfile(testlib.random_name(),
+                ping=bool(x)) for x in range(2)]
         for x in state.management_profiles:
             fw.add(x)
-            x.create()
+
+        fw.create_type(network.ManagementProfile)
 
     def setup_state_obj(self, fw, state):
         state.obj = network.EthernetInterface(
@@ -228,6 +375,7 @@ class TestL3EthernetInterface(testlib.FwFlow):
             except Exception:
                 pass
 
+
 class TestL2EthernetInterface(testlib.FwFlow):
     def create_dependencies(self, fw, state):
         state.management_profiles = []
@@ -258,25 +406,87 @@ class TestL2EthernetInterface(testlib.FwFlow):
             except Exception:
                 pass
 
+
 # AggregateInterface
-# VlanInterface
-# LoopbackInterface
-# TunnelInterface
+
+class TestVlanInterface(testlib.FwFlow):
+    def setup_state_obj(self, fw, state):
+        state.obj = network.VlanInterface(
+            'vlan.{0}'.format(random.randint(20, 5000)),
+            testlib.random_ip('/24'),
+            mtu=random.randint(800, 1000),
+            adjust_tcp_mss=True,
+            comment='Vlan interface',
+            ipv4_mss_adjust=random.randint(100, 200),
+            ipv6_mss_adjust=random.randint(100, 200),
+        )
+        fw.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.ip = None
+        state.obj.comment = 'Updated vlan'
+        state.obj.enable_dhcp = True
+        state.obj.create_dhcp_default_route = True
+        state.obj.dhcp_default_route_metric = random.randint(50, 200)
+
+
+class TestLoopbackInterface(testlib.FwFlow):
+    def setup_state_obj(self, fw, state):
+        state.obj = network.LoopbackInterface(
+            'loopback.{0}'.format(random.randint(20, 5000)),
+            testlib.random_ip(),
+            mtu=random.randint(800, 1000),
+            adjust_tcp_mss=True,
+            comment='Some loopback interface',
+            ipv4_mss_adjust=random.randint(100, 200),
+            ipv6_mss_adjust=random.randint(100, 200),
+        )
+        fw.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.ip = testlib.random_ip()
+        state.obj.comment = 'Updated loopback'
+
+
+class TestTunnelInterface(testlib.FwFlow):
+    def setup_state_obj(self, fw, state):
+        state.obj = network.TunnelInterface(
+            'tunnel.{0}'.format(random.randint(20, 5000)),
+            testlib.random_ip('/24'),
+            mtu=random.randint(800, 1000),
+            comment='Underground interface',
+        )
+        fw.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.ip = testlib.random_ip('/24')
+        state.obj.comment = 'Updated tunnel'
+
 
 class TestStaticRoute(testlib.FwFlow):
     def create_dependencies(self, fw, state):
-        state.vr = network.VirtualRouter(testlib.random_name())
+        state.eth_obj = None
+        state.eth = testlib.get_available_interfaces(fw)[0]
+
+        state.eth_obj = network.EthernetInterface(
+            state.eth, 'layer3', testlib.random_ip('/24'))
+        fw.add(state.eth_obj)
+        state.eth_obj.create()
+
+        state.vr = network.VirtualRouter(
+            testlib.random_name(), interface=state.eth)
         fw.add(state.vr)
         state.vr.create()
 
     def setup_state_obj(self, fw, state):
         state.obj = network.StaticRoute(
             testlib.random_name(),
-            destination=testlib.random_ip('/32'),
-            nexthop_type='ip-address',
-            nexthop=testlib.random_ip(),
-            admin_dist=random.randint(10, 240),
-            metric=random.randint(1, 65535),
+            testlib.random_ip('/32'),
+            'ip-address',
+            testlib.random_ip(),
+            state.eth,
+            random.randint(10, 240),
+            random.randint(1, 65535),
         )
         state.vr.add(state.obj)
 
@@ -284,6 +494,7 @@ class TestStaticRoute(testlib.FwFlow):
         state.obj.destination = testlib.random_ip('/32')
         state.obj.nexthop_type = 'discard'
         state.obj.nexthop = None
+        state.obj.interface = None
 
     def cleanup_dependencies(self, fw, state):
         try:
@@ -291,7 +502,57 @@ class TestStaticRoute(testlib.FwFlow):
         except Exception:
             pass
 
-# StaticRouteV6
+        try:
+            state.eth_obj.delete()
+        except Exception:
+            pass
+
+
+class TestStaticRouteV6(testlib.FwFlow):
+    def create_dependencies(self, fw, state):
+        state.eth_obj = None
+        state.eth = testlib.get_available_interfaces(fw)[0]
+
+        state.eth_obj = network.EthernetInterface(
+            state.eth, 'layer3', testlib.random_ip('/24'), ipv6_enabled=True)
+        fw.add(state.eth_obj)
+        state.eth_obj.create()
+
+        state.vr = network.VirtualRouter(
+            testlib.random_name(), interface=state.eth)
+        fw.add(state.vr)
+        state.vr.create()
+
+    def setup_state_obj(self, fw, state):
+        ip = testlib.random_ipv6('')
+        state.obj = network.StaticRouteV6(
+            testlib.random_name(),
+            destination=ip + '/64',
+            nexthop_type='ipv6-address',
+            nexthop=ip + '1',
+            interface=state.eth,
+            admin_dist=random.randint(100, 200),
+            metric=random.randint(1, 65535),
+        )
+        state.vr.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.destination = testlib.random_ipv6('/64')
+        state.obj.nexthop_type = 'discard'
+        state.obj.nexthop = None
+        state.obj.interface = None
+
+    def cleanup_dependencies(self, fw, state):
+        try:
+            state.vr.delete()
+        except Exception:
+            pass
+
+        try:
+            state.eth_obj.delete()
+        except Exception:
+            pass
+
 
 class TestVirtualRouter(testlib.FwFlow):
     def create_dependencies(self, fw, state):
@@ -329,21 +590,51 @@ class TestVirtualRouter(testlib.FwFlow):
         except Exception:
             pass
 
-class OspfFlow(testlib.FwFlow):
+
+class MakeVirtualRouter(testlib.FwFlow):
+    WITH_OSPF = False
+    WITH_AREA = False
+    WITH_AUTH_PROFILE = False
+    WITH_AREA_INTERFACE = False
+
     def create_dependencies(self, fw, state):
-        state.eth_objs = []
-        state.vr = None
         state.eths = testlib.get_available_interfaces(fw, 2)
 
-        for e in state.eths:
-            state.eth_objs.append(network.EthernetInterface(
-                e, 'layer3', testlib.random_ip('/24')))
-            fw.add(state.eth_objs[-1])
-            state.eth_objs[-1].create()
+        state.eth_obj_v4 = network.EthernetInterface(
+            state.eths[0], 'layer3', testlib.random_ip('/24'))
+        fw.add(state.eth_obj_v4)
+
+        state.eth_obj_v6 = network.EthernetInterface(
+            state.eths[1], 'layer3', ipv6_enabled=True)
+        fw.add(state.eth_obj_v6)
+
+        fw.create_type(network.EthernetInterface)
 
         state.vr = network.VirtualRouter(testlib.random_name(), state.eths)
         fw.add(state.vr)
         state.vr.create()
+
+        if any((self.WITH_OSPF, self.WITH_AUTH_PROFILE,
+               self.WITH_AREA, self.WITH_AREA_INTERFACE)):
+            state.ospf = network.Ospf(
+                True, testlib.random_ip())
+            state.vr.add(state.ospf)
+
+            if self.WITH_AUTH_PROFILE:
+                state.auth = network.OspfAuthProfile(
+                    testlib.random_name(), 'md5')
+                state.ospf.add(state.auth)
+
+            if self.WITH_AREA or self.WITH_AREA_INTERFACE:
+                state.area = network.OspfArea(testlib.random_ip())
+                state.ospf.add(state.area)
+
+                if self.WITH_AREA_INTERFACE:
+                    state.iface = network.OspfAreaInterface(
+                        state.eths[0], True, True, 'p2mp')
+                    state.area.add(state.iface)
+
+            state.ospf.create()
 
     def cleanup_dependencies(self, fw, state):
         try:
@@ -351,17 +642,16 @@ class OspfFlow(testlib.FwFlow):
         except Exception:
             pass
 
-        for e in state.eth_objs:
-            try:
-                e.delete()
-            except Exception:
-                pass
+        try:
+            fw.delete_type(network.EthernetInterface)
+        except Exception:
+            pass
 
-class TestRedistributionProfile(OspfFlow):
+
+class TestRedistributionProfile(MakeVirtualRouter):
     def setup_state_obj(self, fw, state):
         some_ip = testlib.random_ip()
 
-        # TODO(gfreeman) - add bgp_filter_* params
         state.obj = network.RedistributionProfile(
             testlib.random_name(),
             priority=random.randint(1, 255),
@@ -380,16 +670,173 @@ class TestRedistributionProfile(OspfFlow):
         state.obj.action = 'redist'
         state.obj.filter_type = ('ospf', 'rip', 'bgp')
         state.obj.ospf_filter_pathtype = ('inter-area', 'ext-2')
+        state.obj.bgp_filter_community = ('local-as', 'no-export')
 
-# Ospf
-# OspfArea
-# OspfRange
-# OspfNssaExternalRange
-# OspfAreaInterface
-# OspfNeighbor
-# OspfAuthProfile
-# OspfAuthProfileMd5
-# OspfExportRules
+
+class TestOspf(MakeVirtualRouter):
+    def setup_state_obj(self, fw, state):
+        state.obj = network.Ospf(
+            True, testlib.random_ip(), True, True, True,
+            2, 3, False, 300, False, False, 400)
+        state.vr.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.enable = False
+        state.obj.reject_default_route = False
+        state.allow_redist_default_route = False
+        state.obj.rfc1583 = False
+        state.obj.spf_calculation_delay = 3
+        state.obj.lsa_interval = 4
+        state.obj.graceful_restart_enable = True
+        state.obj.gr_helper_enable = True
+        state.obj.gr_strict_lsa_checking = True
+
+
+class TestOspfArea(MakeVirtualRouter):
+    WITH_OSPF = True
+
+    def setup_state_obj(self, fw, state):
+        state.obj = network.OspfArea(
+            testlib.random_ip(), 'normal')
+        state.ospf.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.type = 'stub'
+        state.obj.accept_summary = True
+        state.obj.default_route_advertise = 'disable'
+
+    def test_05_stub_area_with_default_route_advertise(self, fw, state_map):
+        state = self.sanity(fw, state_map)
+
+        state.obj.default_route_advertise = 'advertise'
+        state.obj.default_route_advertise_metric = 45
+
+        state.obj.apply()
+
+    def test_06_nssa_area_type_ext1(self, fw, state_map):
+        state = self.sanity(fw, state_map)
+
+        state.obj.type = 'nssa'
+        state.obj.default_route_advertise_type = 'ext-1'
+
+        state.obj.apply()
+
+    def test_07_nssa_area_type_ext2(self, fw, state_map):
+        state = self.sanity(fw, state_map)
+
+        state.obj.default_route_advertise_type = 'ext-2'
+
+        state.obj.apply()
+
+
+class TestOspfRange(MakeVirtualRouter):
+    WITH_AREA = True
+
+    def setup_state_obj(self, fw, state):
+        state.obj = network.OspfRange(testlib.random_ip(), 'advertise')
+        state.area.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.mode = 'suppress'
+
+
+class TestOspfNssaExternalRange(MakeVirtualRouter):
+    WITH_AREA = True
+
+    def create_dependencies(self, fw, state):
+        super(TestOspfNssaExternalRange, self).create_dependencies(fw, state)
+        state.area.type = 'nssa'
+        state.area.apply()
+
+    def setup_state_obj(self, fw, state):
+        state.obj = network.OspfNssaExternalRange(
+            testlib.random_ip('/24'), 'advertise')
+        state.area.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.mode = 'suppress'
+
+
+class TestOspfAreaInterface(MakeVirtualRouter):
+    WITH_AREA = True
+    WITH_AUTH_PROFILE = True
+
+    def setup_state_obj(self, fw, state):
+        state.obj = network.OspfAreaInterface(
+            random.choice(state.eths), True, True, 'broadcast', 4096, 50,
+            12, 3, 4, 5, 6, state.auth.uid)
+        state.area.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.enable = False
+        state.obj.passive = False
+        state.obj.link_type = 'p2p'
+
+    def test_05_link_type_p2mp(self, fw, state_map):
+        state = self.sanity(fw, state_map)
+
+        state.obj.enable = True
+        state.obj.link_type = 'p2mp'
+
+        state.obj.apply()
+
+
+class TestOspfNeighbor(MakeVirtualRouter):
+    WITH_AREA_INTERFACE = True
+
+    def setup_state_obj(self, fw, state):
+        state.obj = network.OspfNeighbor(testlib.random_ip(), 10)
+        state.iface.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.metric = 11
+
+
+class TestOspfAuthProfile(MakeVirtualRouter):
+    WITH_OSPF = True
+
+    def setup_state_obj(self, fw, state):
+        state.obj = network.OspfAuthProfile(
+            testlib.random_name(), 'password', 'secret')
+        state.ospf.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.password = 'secret2'
+
+
+class TestOspfAuthProfileMd5(MakeVirtualRouter):
+    WITH_AUTH_PROFILE = True
+
+    def setup_state_obj(self, fw, state):
+        state.obj = network.OspfAuthProfileMd5(
+            '1', 'secret1', False)
+        state.auth.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.preferred = True
+
+    def test_05_add_second_profile_not_preferred(self, fw, state_map):
+        state = self.sanity(fw, state_map)
+
+        o = network.OspfAuthProfileMd5('2', 'secret2', False)
+
+        state.auth.add(o)
+        o.create()
+
+
+class TestOspfExportRules(MakeVirtualRouter):
+    WITH_OSPF = True
+
+    def setup_state_obj(self, fw, state):
+        state.obj = network.OspfExportRules(
+            testlib.random_ip('/24'),
+            'ext-2', testlib.random_ip(), 2048)
+        state.ospf.add(state.obj)
+
+    def update_state_obj(self, fw, state):
+        state.obj.new_path_type = 'ext-1'
+        state.obj.metric = 5309
+
 
 class TestManagementProfile(testlib.FwFlow):
     def setup_state_obj(self, fw, state):
@@ -413,3 +860,4 @@ class TestManagementProfile(testlib.FwFlow):
     def update_state_obj(self, fw, state):
         state.obj.permitted_ip = ['9.8.7.6', ]
         state.obj.https = True
+        state.obj.http_ocsp = False

--- a/tests/live/testlib.py
+++ b/tests/live/testlib.py
@@ -11,6 +11,7 @@ def random_name():
         for x in range(10)
     )
 
+
 def random_ip(netmask=None):
     return '{0}.{1}.{2}.{3}{4}'.format(
         random.randint(11, 150),
@@ -19,6 +20,7 @@ def random_ip(netmask=None):
         1 if netmask is not None else random.randint(2, 200),
         netmask or '',
     )
+
 
 def random_ipv6(ending=None):
     if ending is None:
@@ -31,11 +33,13 @@ def random_ipv6(ending=None):
             random.randint(1, 65535), random.randint(1, 65535),
             random.randint(1, 65535), random.randint(1, 65535), ending)
 
+
 def random_mac():
     return ':'.join(
         '{0:02x}'.format(random.randint(0, 255))
         for x in range(6)
     )
+
 
 def get_available_interfaces(con, num=1):
     ifaces = network.EthernetInterface.refreshall(con, add=False)

--- a/tests/live/testlib.py
+++ b/tests/live/testlib.py
@@ -20,6 +20,23 @@ def random_ip(netmask=None):
         netmask or '',
     )
 
+def random_ipv6(ending=None):
+    if ending is None:
+        return ':'.join(
+            '{0:04x}'.format(random.randint(1, 65535))
+            for x in range(8)
+        )
+    else:
+        return '{0:04x}:{1:04x}:{2:04x}:{3:04x}::{4}'.format(
+            random.randint(1, 65535), random.randint(1, 65535),
+            random.randint(1, 65535), random.randint(1, 65535), ending)
+
+def random_mac():
+    return ':'.join(
+        '{0:02x}'.format(random.randint(0, 255))
+        for x in range(6)
+    )
+
 def get_available_interfaces(con, num=1):
     ifaces = network.EthernetInterface.refreshall(con, add=False)
     ifaces = set(x.name for x in ifaces)
@@ -74,7 +91,8 @@ class FwFlow(object):
     def test_03_refreshall(self, fw, state_map):
         state = self.sanity(fw, state_map)
 
-        state.obj.refreshall(state.obj.parent, add=False)
+        objs = state.obj.refreshall(state.obj.parent, add=False)
+        assert len(objs) >= 1
 
     def test_04_update(self, fw, state_map):
         state = self.sanity(fw, state_map)
@@ -139,7 +157,8 @@ class DevFlow(object):
     def test_03_refreshall(self, dev, state_map):
         state = self.sanity(dev, state_map)
 
-        state.obj.refreshall(state.obj.parent, add=False)
+        objs = state.obj.refreshall(state.obj.parent, add=False)
+        assert len(objs) >= 1
 
     def test_04_update(self, dev, state_map):
         state = self.sanity(dev, state_map)
@@ -205,7 +224,8 @@ class PanoFlow(object):
     def test_03_refreshall(self, pano, state_map):
         state = self.sanity(pano, state_map)
 
-        state.obj.refreshall(state.obj.parent, add=False)
+        objs = state.obj.refreshall(state.obj.parent, add=False)
+        assert len(objs) >= 1
 
     def test_04_update(self, pano, state_map):
         state = self.sanity(pano, state_map)


### PR DESCRIPTION
Additionally:
* Fixes `__repr__` for devices with `self.NAME == None`
* Fixes `StaticRouteV6`
* Fixes xpath for `OspfNssaExternalRange`
* Adding `exclude=True` to `OspfNeighbor.metric` as attempting to use this results in an error

All live network tests ran against 6.1 - 8.0
