### PR TITLE
Fixes PaloAltoNetworks/pandevice#70 - support limited vsys refresh

### DIFF
--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -785,7 +785,6 @@ class PanObject(object):
         """Get the XML for a single PanObject."""
         # Get the root of the xml to parse
         optimized = False
-        err_msg = "Object doesn't exist: {0}".format(xpath)
         dev = self.nearest_pandevice()
         msg = '{0}: refreshing xml on {1} object {2}'.format(
             dev.id, type(self), self.uid)
@@ -805,6 +804,7 @@ class PanObject(object):
                 '{0}/{1}'.format(self.xpath(), x)
                 for x in query_paths)
 
+        err_msg = "Object doesn't exist: {0}".format(xpath)
         # Query the live device
         try:
             root = api_action(xpath, retry_on_peer=self.HA_SYNC)
@@ -831,7 +831,7 @@ class PanObject(object):
                     elm.append(se)
 
         if elm is None and exceptions:
-            raise err.PanObjectMissing(err_msg, pan_device=device)
+            raise err.PanObjectMissing(err_msg, pan_device=dev)
 
         return elm
 

--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -1035,18 +1035,16 @@ class PanObject(object):
             raise ValueError("can't get name_only from running_config")
         if name_only and cls.SUFFIX != ENTRY:
             raise ValueError("name_only is invalid, can only be used on entry type objects")
-        if isinstance(parent, PanDevice):
-            device = parent
-            parent_xpath = parent.xpath_root(cls.ROOT)
-        else:
-            device = parent.nearest_pandevice()
-            parent_xpath = parent.xpath()
-        logger.debug(device.id + ": refreshall called on %s type" % cls)
 
         # Versioned objects need a PanDevice to get the version from, so
         # set the child's parent before accessing XPATH.
         class_instance = cls()
         class_instance.parent = parent
+
+        device = class_instance.nearest_pandevice()
+        logger.debug(device.id + ": refreshall called on %s type" % cls)
+
+        parent_xpath = class_instance._parent_xpath()
 
         # Set api_action and xpath
         api_action = device.xapi.show if running_config else device.xapi.get

--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -785,6 +785,7 @@ class PanObject(object):
         """Get the XML for a single PanObject."""
         # Get the root of the xml to parse
         optimized = False
+        err_msg = "Object doesn't exist: {0}".format(xpath)
         dev = self.nearest_pandevice()
         msg = '{0}: refreshing xml on {1} object {2}'.format(
             dev.id, type(self), self.uid)
@@ -809,7 +810,6 @@ class PanObject(object):
             root = api_action(xpath, retry_on_peer=self.HA_SYNC)
         except (pan.xapi.PanXapiError, err.PanNoSuchNode) as e:
             if exceptions:
-                err_msg = "Object doesn't exist: {0}".format(xpath)
                 raise err.PanObjectMissing(err_msg, pan_device=dev)
             else:
                 return

--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -637,7 +637,8 @@ class PanObject(object):
 
         return (varpath, value, var)
 
-    def refresh(self, running_config=False, refresh_children=True, exceptions=True, xml=None):
+    def refresh(self, running_config=False, refresh_children=True,
+                exceptions=True, xml=None):
         """Refresh all variables and child objects from the device.
 
         Args:
@@ -653,7 +654,8 @@ class PanObject(object):
         """
         # Either retrieve the xml or use what is passed in
         if xml is None:
-            xml = self._refresh_xml(running_config, exceptions)
+            xml = self._refresh_xml(running_config, exceptions,
+                                    refresh_children)
         else:
             logger.debug('refresh called using xml on {0} object "{1}"'.format(
                 type(self), self.uid))
@@ -779,35 +781,54 @@ class PanObject(object):
 
         return self.children
 
-    def _refresh_xml(self, running_config, exceptions):
+    def _refresh_xml(self, running_config, exceptions, refresh_children=True):
         """Get the XML for a single PanObject."""
         # Get the root of the xml to parse
-        device = self.nearest_pandevice()
+        optimized = False
+        dev = self.nearest_pandevice()
         msg = '{0}: refreshing xml on {1} object {2}'.format(
-            device.id, type(self), self.uid)
+            dev.id, type(self), self.uid)
         logger.debug(msg)
-        if running_config:
-            api_action = device.xapi.show
+
+        api_action = dev.xapi.show if running_config else dev.xapi.get
+
+        if running_config or refresh_children:
+            xpath = self.xpath()
         else:
-            api_action = device.xapi.get
-        xpath = self.xpath()
-        err_msg = "Object doesn't exist: {0}".format(xpath)
+            optimized = True
+            info = self._build_element_info()
+            paths, settings = info[0], info[2]
+            query_paths = list(set(
+                p.path.split('/')[0].format(**settings) for p in paths))
+            xpath = '|'.join(
+                '{0}/{1}'.format(self.xpath(), x)
+                for x in query_paths)
 
         # Query the live device
         try:
             root = api_action(xpath, retry_on_peer=self.HA_SYNC)
         except (pan.xapi.PanXapiError, err.PanNoSuchNode) as e:
             if exceptions:
-                raise err.PanObjectMissing(err_msg, pan_device=device)
+                err_msg = "Object doesn't exist: {0}".format(xpath)
+                raise err.PanObjectMissing(err_msg, pan_device=dev)
             else:
                 return
 
         # Determine the first element to look for in the XML
-        if self.SUFFIX is None:
-            lasttag = self.XPATH.rsplit("/", 1)[-1]
+        if not optimized:
+            # Normal XML recovery for parsing
+            if self.SUFFIX is None:
+                lasttag = self.XPATH.rsplit("/", 1)[-1]
+            else:
+                lasttag = re.match(r'^/(\w*?)\[', self.SUFFIX).group(1)
+            elm = root.find("result/" + lasttag)
         else:
-            lasttag = re.match(r'^/(\w*?)\[', self.SUFFIX).group(1)
-        elm = root.find("result/" + lasttag)
+            # Construct the XML for parsing.
+            elm = self._root_element()
+            results = root.find('./result')
+            if results is not None:
+                for se in results:
+                    elm.append(se)
 
         if elm is None and exceptions:
             raise err.PanObjectMissing(err_msg, pan_device=device)

--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -2608,7 +2608,10 @@ class VsysOperations(VersionedPanObject):
             self.create_import()
 
     def child_delete(self):
-        self.delete_import()
+        if self.ALWAYS_IMPORT and self.vsys is None:
+            self.delete_import('vsys1')
+        else:
+            self.delete_import()
 
     def create_import(self, vsys=None):
         """Create a vsys import for the object

--- a/pandevice/device.py
+++ b/pandevice/device.py
@@ -103,9 +103,9 @@ class Vsys(PanObject):
         if self.name == "shared":
             return "/config/shared"
         elif self.name is None:
-            return "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']"
+            return self._root_xpath_vsys('vsys1')
         else:
-            return "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='%s']" % self.name
+            return self._root_xpath_vsys(self.name)
 
     def _build_xpath(self, root):
         if root == Root.VSYS:

--- a/pandevice/firewall.py
+++ b/pandevice/firewall.py
@@ -152,9 +152,9 @@ class Firewall(PanDevice):
         if self.vsys == "shared":
             return "/config/shared"
         elif self.vsys is None:
-            return "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']"
+            return self._root_xpath_vsys('vsys1')
         else:
-            return "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='%s']" % self.vsys
+            return self._root_xpath_vsys(self.vsys)
 
     def xpath_panorama(self):
         raise err.PanDeviceError("Attempt to modify Panorama configuration on non-Panorama device")
@@ -280,13 +280,13 @@ class Firewall(PanDevice):
             if self.vsys_name is not None:
                 ET.SubElement(element, "display-name").text = self.vsys_name
             self.set_config_changed()
-            self.xapi.set(self.xpath_device() + "/vsys", ET.tostring(element), retry_on_peer=True)
+            self.xapi.set(self._root_xpath_vsys(None), ET.tostring(element), retry_on_peer=True)
 
     def delete_vsys(self):
         """Delete the vsys on the live device that this Firewall object represents"""
         if self.vsys.startswith("vsys"):
             self.set_config_changed()
-            self.xapi.delete(self.xpath_device() + "/vsys/entry[@name='%s']" % self.vsys, retry_on_peer=True)
+            self.xapi.delete(self._root_xpath_vsys(self.vsys), retry_on_peer=True)
 
     def refreshall_from_xml(self, xml, refresh_children=False, variables=None):
         if len(xml) == 0:


### PR DESCRIPTION
```
In [1]: from pandevice import firewall, device

In [2]: c = firewall.Firewall('<snip>.25', ...)

In [3]: c.refresh_system_info()
Out[3]: SystemInfo(version='7.0.1', platform='PA-3020', serial='<snip>')

In [4]: device.Vsys.refreshall(c, name_only=True)
Out[4]: [<Vsys vsys1 0x10a31f890>, <Vsys vsys2 0x10a31fe50>, <Vsys vsys3 0x10a31ff50>]

In [5]: vsys = _[2]

In [6]: vsys.about()
Out[6]: 
{'decrypt_forwarding': None,
 'display_name': None,
 'dns_proxy': None,
 'interface': None,
 'name': 'vsys3',
 'virtual_routers': None,
 'virtual_wires': None,
 'visible_vsys': None,
 'vlans': None}

In [7]: vsys.refresh(refresh_children=False)

In [8]: vsys.about()
Out[8]: 
{'decrypt_forwarding': True,
 'display_name': 'ACI-DoubleOspf-5235',
 'dns_proxy': 'foo',
 'interface': ['ethernet1/12.1240',
  'ethernet1/12.1250',
  'ethernet1/16',
  'ethernet1/17'],
 'name': 'vsys3',
 'virtual_routers': ['ACI-DoubleOspf-5235_vsys3'],
 'virtual_wires': ['yoo'],
 'visible_vsys': ['vsys2', 'vsys1'],
 'vlans': ['test3']}

In [9]: c.vsys = 'vsys3'

In [10]: r = device.VsysResources()

In [11]: c.add(r)
Out[11]: <VsysResources 0x10a365d90>

In [12]: r.refresh()

In [13]: r.about()
Out[13]: 
{'max_application_override_rules': 105,
 'max_concurrent_ssl_vpn_tunnels': 110,
 'max_cp_rules': 107,
 'max_dos_rules': 108,
 'max_nat_rules': 102,
 'max_pbf_rules': 106,
 'max_qos_rules': 104,
 'max_security_rules': 101,
 'max_sessions': 5579,
 'max_site_to_site_vpn_tunnels': 109,
 'max_ssl_decryption_rules': 103}
```