### PR TITLE
Fixes PaloAltoNetworks/pandevice#68 - fixes equal()

### DIFF
--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -338,10 +338,11 @@ class PanObject(object):
         specific_vsys = "/entry[@name='{0}']".format(vsys) if vsys else ""
         return root_xpath + specific_vsys
 
-    def element(self, comparable=False):
+    def element(self, with_children=True, comparable=False):
         """Construct an ElementTree for this PanObject and all its children
 
         Args:
+            with_children (bool): Include children in element.
             comparable (bool): Element will be used in a comparison with another.
 
         Returns:
@@ -421,7 +422,10 @@ class PanObject(object):
             if missing_replacement:
                 continue
             var._set_inner_xml_tag_text(nextelement, value, comparable)
-        self.xml_merge(root, self._subelements())
+
+        if with_children:
+            self.xml_merge(root, self._subelements())
+
         return root
 
     def element_str(self):
@@ -1959,11 +1963,11 @@ class VersionedPanObject(PanObject):
 
         return (paths, stubs, settings)
 
-    def element(self, compare_children=True, comparable=False):
+    def element(self, with_children=True, comparable=False):
         """Return an xml.etree.ElementTree for this object and its children.
 
         Args:
-            compare_children (bool): Include the children objects.
+            with_children (bool): Include the children objects.
             comparable (bool): Element will be used in a comparison with another.
 
         Returns:
@@ -1977,7 +1981,7 @@ class VersionedPanObject(PanObject):
             (p.element(self._root_element(), settings, comparable) for p in paths),
             (s.element(self._root_element(), settings, comparable) for s in stubs),
         )
-        if compare_children:
+        if with_children:
             iterchain += (self._subelements(comparable), )
 
         self.xml_merge(ans, itertools.chain(*iterchain))

--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -72,11 +72,14 @@ class PanObject(object):
 
     def __init__(self, *args, **kwargs):
         # Set the 'name' variable
-        try:
-            name = args[0]
-        except IndexError:
-            name = kwargs.pop(self.NAME, None)
-        setattr(self, self.NAME, name)
+        idx_start = 0
+        if self.NAME is not None:
+            try:
+                name = args[0]
+                idx_start = 1
+            except IndexError:
+                name = kwargs.pop(self.NAME, None)
+            setattr(self, self.NAME, name)
         # Initialize other common variables
         self.parent = None
         self.children = []
@@ -87,11 +90,11 @@ class PanObject(object):
             variables = type(self).variables()
         # Sort the variables by order
         variables = sorted(variables, key=lambda x: x.order)
-        for idx, var in enumerate(variables):
+        for idx, var in enumerate(variables, idx_start):
             varname = var.variable
             try:
                 # Try to get the variables from 'args' first
-                varvalue = args[idx+1]
+                varvalue = args[idx]
             except IndexError:
                 # If it's not in args, get it from 'kwargs', or store a None in the variable
                 try:
@@ -442,7 +445,7 @@ class PanObject(object):
         raise ValueError('No suffix or XPATH defined for {0}'.format(
                          self.__class__.__name__))
 
-    def _subelements(self, comparison_element=False):
+    def _subelements(self, comparable=False):
         """Generator function to turn children into XML objects.
 
         Yields:
@@ -460,10 +463,7 @@ class PanObject(object):
             e = root
             for path in xpath_sections:
                 e = ET.SubElement(e, path)
-            if comparison_element:
-                e.append(child.comparison_element())
-            else:
-                e.append(child.element())
+            e.append(child.element(comparable))
             yield root
 
     def _check_child_methods(self, method):
@@ -1829,6 +1829,7 @@ class VersionedPanObject(PanObject):
         The setup includes configuring the following:
 
         * _xpaths
+        * _xpath_imports (VsysOperations objects only)
         * _params
         * _stubs
 
@@ -1955,42 +1956,26 @@ class VersionedPanObject(PanObject):
 
         return (paths, stubs, settings)
 
-    def element(self):
+    def element(self, compare_children=True, comparable=False):
         """Return an xml.etree.ElementTree for this object and its children.
 
-        Returns:
-            An xml.etree.ElementTree instance representing the xml form of this
-                object and its children
-
-        """
-        ans = self._root_element()
-        paths, stubs, settings = self._build_element_info()
-
-        self.xml_merge(ans, itertools.chain(
-                (p.element(self._root_element(), settings) for p in paths),
-                (s.element(self._root_element(), settings) for s in stubs),
-                self._subelements(),
-        ))
-
-        return ans
-
-    def comparison_element(self, compare_children=True):
-        """Return an xml.etree.ElementTree for this object and its children.
+        Args:
+            compare_children (bool): Include the children objects.
+            comparable (bool): Element will be used in a comparison with another.
 
         Returns:
-            An xml.etree.ElementTree instance representing the xml form of this
-                object and its children
+            xml.etree.ElementTree for this object.
 
         """
         ans = self._root_element()
         paths, stubs, settings = self._build_element_info()
 
         iterchain = (
-            (p.element(self._root_element(), settings, sha1=True) for p in paths),
-            (s.element(self._root_element(), settings, sha1=True) for s in stubs),
+            (p.element(self._root_element(), settings, comparable) for p in paths),
+            (s.element(self._root_element(), settings, comparable) for s in stubs),
         )
         if compare_children:
-            iterchain += (self._subelements(comparison_element=True),)
+            iterchain += (self._subelements(comparable), )
 
         self.xml_merge(ans, itertools.chain(*iterchain))
 
@@ -2018,12 +2003,15 @@ class VersionedPanObject(PanObject):
         if not panobject:
             return False
         if type(self) != type(panobject) and not force:
-            raise err.PanObjectError("Object {0} is not comparable to {1}".format(type(self), type(panobject)))
+            msg = 'Object {0} is not compareable to {1}'
+            raise err.PanObjectError(msg.format(self, panobject))
 
-        self_element = self.comparison_element(compare_children)
-        other_element = panobject.comparison_element(compare_children)
+        xml_self = ET.tostring(self.element(compare_children, True),
+            encoding='utf-8')
+        xml_other = ET.tostring(panobject.element(compare_children, True),
+            encoding='utf-8')
 
-        return ET.tostring(self_element, encoding='utf-8') == ET.tostring(other_element, encoding='utf-8')
+        return xml_self == xml_other
 
     def _get_param_specific_info(self, param):
         """Gets a tuple of info for the given parameter.
@@ -2359,7 +2347,7 @@ class ParamPath(object):
         else:
             yield str(value)
 
-    def element(self, elm, settings, sha1=False):
+    def element(self, elm, settings, comparable=False):
         """Create the xml.etree.ElementTree for this parameter.
 
         Args:
@@ -2367,7 +2355,7 @@ class ParamPath(object):
                 onto this param's XML.
             settings (dict): All parameter settings for the
                 ``VersionedPanObject``.
-            sha1 (bool): Hash encrypted fields for comparison
+            comparable (bool): Make necessary adjustments to the XML for comparison's sake.
 
         Returns:
             xml.etree.ElementTree: The ``elm`` passed in, modified to contain
@@ -2412,7 +2400,7 @@ class ParamPath(object):
             e.append(child)
             e = child
 
-        self._set_inner_xml_tag_text(e, value, sha1)
+        self._set_inner_xml_tag_text(e, value, comparable)
 
         return elm
 
@@ -2510,21 +2498,27 @@ class ParamPath(object):
         # Pull the value, properly formatted, from this last element
         self.parse_value_from_xml_last_tag(e, settings)
 
-    def _set_inner_xml_tag_text(self, elm, value, sha1=False):
+    def _set_inner_xml_tag_text(self, elm, value, comparable=False):
         """Sets the final elm's .text as appropriate given the vartype.
 
         Args:
             elm (xml.etree.ElementTree.Element): The element whose .text to set.
             value (various): The value to put in the .text, conforming to the vartype of this parameter.
-            sha1 (bool): For encrypted fields, if the text should be set to a password hash (True) or left as a basestring (False)
+            comparable (bool): Make updates for element string comparisons.  For encrypted fields, if the text should be set to a password hash (True) or left as a basestring (False).  For entry and member vartypes, sort the entries (True) or leave them as-is (False).
 
         """
         # Format the element text appropriately
         if self.vartype == 'member':
-            for v in self._value_as_list(value):
+            values = self._value_as_list(value)
+            if comparable:
+                values = sorted(values)
+            for v in values:
                 ET.SubElement(elm, 'member').text = v
         elif self.vartype == 'entry':
-            for v in self._value_as_list(value):
+            values = self._value_as_list(value)
+            if comparable:
+                values = sorted(values)
+            for v in values:
                 ET.SubElement(elm, 'entry', {'name': v})
         elif self.vartype == 'exist':
             if value:
@@ -2537,7 +2531,7 @@ class ParamPath(object):
             pass
         elif self.vartype == 'int':
             elm.text = str(int(value))
-        elif self.vartype == 'encrypted' and sha1:
+        elif self.vartype == 'encrypted' and comparable:
             elm.text = self._sha1_hash(str(value))
         else:
             elm.text = str(value)

--- a/pandevice/device.py
+++ b/pandevice/device.py
@@ -229,6 +229,7 @@ class SystemSettings(PanObject):
         update_server (str): IP or hostname of the update server
 
     """
+    NAME = None
     ROOT = Root.DEVICE
     XPATH = "/deviceconfig/system"
     HA_SYNC = False

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1375,5 +1375,76 @@ class TestParentAwareXpathWithParams(unittest.TestCase):
                 Base.VersionedPanObject._UNKNOWN_PANOS_VERSION, parent))
 
 
+class MyVersionedObject(Base.VersionedPanObject):
+    SUFFIX = Base.ENTRY
+
+    def _setup(self):
+        params = []
+
+        params.append(Base.VersionedParamPath(
+            'entries', path='multiple/entries', vartype='entry'))
+        params.append(Base.VersionedParamPath(
+            'members', path='multiple/members', vartype='member'))
+        params.append(Base.VersionedParamPath(
+            'someint', path='someint', vartype='int'))
+
+        self._params = tuple(params)
+
+
+class TestEqual(unittest.TestCase):
+    def test_ordered(self):
+        o1 = MyVersionedObject('a', ['a', 'b'], ['c', 'd'], 5)
+        o2 = MyVersionedObject('a', ['a', 'b'], ['c', 'd'], 5)
+
+        self.assertTrue(o1.equal(o2))
+
+    def test_unordered_entries(self):
+        o1 = MyVersionedObject('a', ['a', 'b'], ['c', 'd'], 5)
+        o2 = MyVersionedObject('a', ['b', 'a'], ['c', 'd'], 5)
+
+        self.assertTrue(o1.equal(o2))
+
+    def test_unordered_members(self):
+        o1 = MyVersionedObject('a', ['a', 'b'], ['c', 'd'], 5)
+        o2 = MyVersionedObject('a', ['a', 'b'], ['d', 'c'], 5)
+
+        self.assertTrue(o1.equal(o2))
+
+    def test_values_are_unchanged_after_comparison(self):
+        o1 = MyVersionedObject('a', ['a', 'b'], ['c', 'd'], 5)
+        o2 = MyVersionedObject('a', ['b', 'a'], ['d', 'c'], 5)
+
+        o1.equal(o2)
+
+        self.assertEqual(o1.entries, ['a', 'b'])
+        self.assertEqual(o1.members, ['c', 'd'])
+        self.assertEqual(o2.entries, ['b', 'a'])
+        self.assertEqual(o2.members, ['d', 'c'])
+
+    def test_str_list_field_is_equal(self):
+        o1 = MyVersionedObject('a', ['a', ], ['c', 'd'], 5)
+        o2 = MyVersionedObject('a', 'a', ['c', 'd'], 5)
+
+        self.assertTrue(o1.equal(o2))
+
+    def test_unequal_entries_returns_false(self):
+        o1 = MyVersionedObject('a', ['a', 'b'], ['c', 'd'], 5)
+        o2 = MyVersionedObject('a', ['a', 'i'], ['c', 'd'], 5)
+
+        self.assertFalse(o1.equal(o2))
+
+    def test_unequal_members_returns_false(self):
+        o1 = MyVersionedObject('a', ['a', 'b'], ['c', 'd'], 5)
+        o2 = MyVersionedObject('a', ['a', 'b'], ['c', 'i'], 5)
+
+        self.assertFalse(o1.equal(o2))
+
+    def test_unequal_ints_returns_false(self):
+        o1 = MyVersionedObject('a', ['a', 'b'], ['c', 'd'], 5)
+        o2 = MyVersionedObject('a', ['a', 'b'], ['c', 'd'], 6)
+
+        self.assertFalse(o1.equal(o2))
+
+
 if __name__=='__main__':
     unittest.main()

--- a/tests/test_classic_objects.py
+++ b/tests/test_classic_objects.py
@@ -1,0 +1,24 @@
+from pandevice import device
+
+
+'''
+Note:  All tests in this file are for classic objects.  These are to try and
+make sure that the fix for classic objects with a self.NAME == None still
+work properly.
+
+'''
+
+
+def test_system_settings_with_positional_arg_sets_hostname():
+    ss = device.SystemSettings('foobar')
+
+    assert ss.hostname == 'foobar'
+
+
+def test_system_settings_parsing():
+    ss = device.SystemSettings(hostname='foobar')
+    ss2 = device.SystemSettings()
+
+    ss2.refresh(xml=ss.element())
+
+    assert ss.equal(ss2)

--- a/tests/test_classic_objects.py
+++ b/tests/test_classic_objects.py
@@ -1,12 +1,13 @@
-from pandevice import device
+''' Tests specifically for classic objects.
 
-
-'''
 Note:  All tests in this file are for classic objects.  These are to try and
 make sure that the fix for classic objects with a self.NAME == None still
 work properly.
 
 '''
+
+
+from pandevice import device
 
 
 def test_system_settings_with_positional_arg_sets_hostname():


### PR DESCRIPTION
This also fixes classic style objects, allowing them to have a `self.NAME` of `None`, and updates the SystemSettings object to have a None name.

To make sure this change didn't cause pandevice level regressions, I've verified that the live tests for system settings still pass, and have added a few non-live tests that verify parsing.