### PR TITLE
Fixes PaloAltoNetworks/pandevice#71 - add reorganizer and allow subinterfaces to have vsys/fw objects as parents

### DIFF
--- a/pandevice/firewall.py
+++ b/pandevice/firewall.py
@@ -369,7 +369,6 @@ class Firewall(PanDevice):
             refresh_vsys (bool): Refresh all vsys objects' parameters before doing the reorganization or not.  This is assumed True if create_vsys_objects is True.
 
         """
-        from pandevice import device
         from pandevice import network
 
         # Mapping of device.Vsys params to pandevice classes.

--- a/pandevice/firewall.py
+++ b/pandevice/firewall.py
@@ -18,6 +18,7 @@
 """Palo Alto Networks Firewall object"""
 
 # import modules
+import itertools
 import re
 import logging
 import xml.etree.ElementTree as ET
@@ -359,6 +360,64 @@ class Firewall(PanDevice):
     def commit_policy_and_objects(self, sync=False, exception=False):
         return self._commit(sync=sync, exclude="policy-and-objects",
                             exception=exception)
+
+    def organize_into_vsys(self, create_vsys_objects=True, refresh_vsys=True):
+        """Organizes all imported objects under the appropriate Vsys object.
+
+        Args:
+            create_vsys_objects (bool): Create the vsys objects (True) or use the ones already connected to this firewall (False).
+            refresh_vsys (bool): Refresh all vsys objects' parameters before doing the reorganization or not.  This is assumed True if create_vsys_objects is True.
+
+        """
+        from pandevice import device
+        from pandevice import network
+
+        # Mapping of device.Vsys params to pandevice classes.
+        mapping = {
+            'interface': network.Interface,
+            'vlans': network.Vlan,
+            'virtual_wires': network.VirtualWire,
+            'virtual_routers': network.VirtualRouter,
+        }
+
+        # Optional: create the vsys objects.
+        if create_vsys_objects:
+            device.Vsys.refreshall(self, name_only=True)
+
+        # Vsys to put objects into.
+        available_vsys = [x for x in self.children
+                          if isinstance(x, device.Vsys)]
+
+        # Optional: refresh the vsys params.
+        if create_vsys_objects or refresh_vsys:
+            for x in available_vsys:
+                x.refresh(refresh_children=False)
+
+        # List of objects we need to iterate over.
+        parents = self.children[:]
+
+        # Reorganize into vsys.
+        for x in itertools.chain(parents):
+            # Skip device.Vsys children.
+            if isinstance(x, device.Vsys):
+                continue
+
+            # Add children for later processing.
+            parents.extend(x.children)
+
+            # Check this class against the importable classes.
+            for param, importable_class in mapping.items():
+                if isinstance(x, importable_class):
+                    # Importable class found, check if it should be moved.
+                    for vsys in available_vsys:
+                        if (getattr(vsys, param) is not None and
+                                x.uid in getattr(vsys, param)):
+                            # If its vsys isn't right, move it.
+                            if x.vsys != vsys.uid:
+                                x.parent.remove(x)
+                                vsys.add(x)
+                            break
+                    break
 
 
 class FirewallState(object):

--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -529,10 +529,23 @@ class Subinterface(Interface):
     Do not instantiate this object. Use a subclass.
 
     """
+    _BASE_INTERFACE_NAME = 'entry BASE_INTERFACE_NAME'
+
     def set_name(self):
         """Create a name appropriate for a subinterface if it isn't already"""
         if '.' not in self.name:
             self.name = '{0}.{1}'.format(self.name, self.tag)
+
+    @property
+    def XPATH(self):
+        path = super(Subinterface, self).XPATH
+
+        if self._BASE_INTERFACE_NAME in path:
+            base = self.uid.split('.')[0]
+            path = path.replace(self._BASE_INTERFACE_NAME,
+                                "entry[@name='{0}']".format(base))
+
+        return path
 
 
 class AbstractSubinterface(object):
@@ -669,8 +682,13 @@ class Layer3Subinterface(Subinterface):
     )
 
     def _setup(self):
-        # xpaths
+        # xpaths for parents: EthernetInterface, AggregateInterface)
         self._xpaths.add_profile(value='/layer3/units')
+        # xpaths for parents: firewall.Firewall, device.Vsys
+        self._xpaths.add_profile(
+            parents=('Firewall', 'Vsys'),
+            value=('/network/interface/ethernet/{0}/layer3/units'.format(
+                self._BASE_INTERFACE_NAME)))
 
         # xpath imports
         self._xpath_imports.add_profile(value='/network/interface')
@@ -739,8 +757,13 @@ class Layer2Subinterface(Subinterface):
     ALLOW_SET_VLAN = True
 
     def _setup(self):
-        # xpaths
+        # xpaths for parents: EthernetInterface, AggregateInterface
         self._xpaths.add_profile(value='/layer2/units')
+        # xpaths for parents: firewall.Firewall, device.Vsys
+        self._xpaths.add_profile(
+            parents=('Firewall', 'Vsys'),
+            value=('/network/interface/ethernet/{0}/layer2/units'.format(
+                self._BASE_INTERFACE_NAME)))
 
         # xpath imports
         self._xpath_imports.add_profile(value='/network/interface')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -658,5 +658,64 @@ class TestXpaths_7_0(unittest.TestCase):
 
         self.assertEqual(expected, ret_val)
 
+
+class TestVariousSubinterfaceXpaths(unittest.TestCase):
+    def test_l2_subinterface_with_firewall_parent(self):
+        fw = pandevice.firewall.Firewall('192.168.1.1', 'admin', 'admin', vsys='vsys2')
+        iface = pandevice.network.EthernetInterface('ethernet1/3', 'layer2')
+        eth = pandevice.network.Layer2Subinterface('ethernet1/3.3', 3)
+        iface.add(eth)
+        fw.add(iface)
+
+        expected = eth.xpath()
+
+        fw.add(eth)
+
+        self.assertEqual(expected, eth.xpath())
+
+    def test_l2_subinterface_with_vsys_parent(self):
+        fw = pandevice.firewall.Firewall('192.168.1.1', 'admin', 'admin')
+        vsys = pandevice.device.Vsys('vsys2')
+        iface = pandevice.network.EthernetInterface('ethernet1/3', 'layer2')
+        eth = pandevice.network.Layer2Subinterface('ethernet1/3.3', 3)
+        iface.add(eth)
+        vsys.add(iface)
+        fw.add(vsys)
+
+        expected = eth.xpath()
+
+        vsys.add(eth)
+
+        self.assertEqual(expected, eth.xpath())
+
+    def test_l3_subinterface_with_firewall_parent(self):
+        fw = pandevice.firewall.Firewall('192.168.1.1', 'admin', 'admin', vsys='vsys3')
+        iface = pandevice.network.EthernetInterface('ethernet1/4', 'layer3')
+        eth = pandevice.network.Layer3Subinterface('ethernet1/4.4', 4)
+        iface.add(eth)
+        fw.add(iface)
+
+        expected = eth.xpath()
+
+        fw.add(eth)
+
+        self.assertEqual(expected, eth.xpath())
+
+    def test_l3_subinterface_with_vsys_parent(self):
+        fw = pandevice.firewall.Firewall('192.168.1.1', 'admin', 'admin')
+        vsys = pandevice.device.Vsys('vsys3')
+        iface = pandevice.network.EthernetInterface('ethernet1/4', 'layer3')
+        eth = pandevice.network.Layer2Subinterface('ethernet1/4.4', 4)
+        iface.add(eth)
+        vsys.add(iface)
+        fw.add(vsys)
+
+        expected = eth.xpath()
+
+        vsys.add(eth)
+
+        self.assertEqual(expected, eth.xpath())
+
+
 if __name__=='__main__':
     unittest.main()


### PR DESCRIPTION
Test script:

```
import pprint

from pandevice import firewall, network


def main():
    c = firewall.Firewall(.25, ...)
    print(c.refresh_system_info())

    print('Refreshing importables...')
    network.EthernetInterface.refreshall(c)
    network.Vlan.refreshall(c)
    network.VirtualWire.refreshall(c)
    network.VirtualRouter.refreshall(c)

    print('Before reorg, fw children:')
    pprint.pprint(c.children)
    c.organize_into_vsys()
    print('After reorg, fw children:')
    pprint.pprint(c.children)


if __name__ == '__main__':
    main()
```

Output:
```
SystemInfo(version='7.0.1', platform='PA-3020', serial=<snip>)
Refreshing importables...
Before reorg, fw children:
[<EthernetInterface ethernet1/12 0x103b95cd0>,
 <EthernetInterface ethernet1/1 0x104c1d490>,
 <EthernetInterface ethernet1/16 0x104c24590>,
 <EthernetInterface ethernet1/17 0x104c2ee10>,
 <EthernetInterface ethernet1/19 0x104c3c390>,
 <EthernetInterface ethernet1/14 0x104c3cd50>,
 <EthernetInterface ethernet1/5 0x104c4b0d0>,
 <Vlan v3 0x104c14dd0>,
 <Vlan test1 0x104c14250>,
 <Vlan test3 0x104c07950>,
 <VirtualWire yoo 0x104c07d90>,
 <VirtualRouter ACI-GarOspf-7099_vsys2 0x104c14450>,
 <VirtualRouter ACI-DoubleOspf-5235_vsys3 0x104c1d810>,
 <VirtualRouter test1 0x104c143d0>]
After reorg, fw children:
[<EthernetInterface ethernet1/12 0x103b95cd0>,
 <EthernetInterface ethernet1/14 0x104c3cd50>,
 <Vlan v3 0x104c14dd0>,
 <Vsys vsys1 0x103bab110>,
 <Vsys vsys2 0x103bab6d0>,
 <Vsys vsys3 0x103babed0>]
```