### PR TITLE
Fix dyn_address_group.py example syntax

### DIFF
--- a/examples/dyn_address_group.py
+++ b/examples/dyn_address_group.py
@@ -30,11 +30,11 @@ Tag/untag ip addresses for Dynamic Address Groups on a firewall
 
 Tag the IP 3.3.3.3 with the tag 'linux' and 'apache'::
 
-    $ python dyn_address_group.py 10.0.0.1 admin password 3.3.3.3 linux,apache
+    $ python dyn_address_group.py -r linux,apache 10.0.0.1 admin password 3.3.3.3
 
 Remove the tag apache from the IP 3.3.3.3::
 
-    $ python dyn_address_group.py -u 10.0.0.1 admin password 3.3.3.3 linux
+    $ python dyn_address_group.py -u linux 10.0.0.1 admin password 3.3.3.3
 
 Clear all tags from all IP's::
 


### PR DESCRIPTION
Hi,

The example syntax that is in file dyn_address_group.py is not working as expected.
Here is an example showing the syntax in the file and the correct one:

```
[~]$ python dyn_address_group.py -l 10.24.192.10 admin password 10.6.90.18
No tags for IP: 10.6.90.18
[~]$ python dyn_address_group.py -r 10.24.192.10 admin password 10.6.90.18 test
Traceback (most recent call last):
  File "dyn_address_group.py", line 130, in <module>
    main()
  File "dyn_address_group.py", line 97, in main
    args.password,
  File "/usr/local/lib/python2.7/site-packages/pandevice/base.py", line 3047, in create_from_device
    system_info = device.refresh_system_info()
  File "/usr/local/lib/python2.7/site-packages/pandevice/base.py", line 3455, in refresh_system_info
    system_info = self.show_system_info()
  File "/usr/local/lib/python2.7/site-packages/pandevice/base.py", line 3412, in show_system_info
    root = self.xapi.op(cmd="show system info", cmd_xml=True)
  File "/usr/local/lib/python2.7/site-packages/pandevice/base.py", line 3277, in xapi
    self._xapi_private = self.generate_xapi()
  File "/usr/local/lib/python2.7/site-packages/pandevice/base.py", line 3319, in generate_xapi
    kwargs = {'api_key': self.api_key,
  File "/usr/local/lib/python2.7/site-packages/pandevice/base.py", line 3271, in api_key
    self._api_key = self._retrieve_api_key()
  File "/usr/local/lib/python2.7/site-packages/pandevice/base.py", line 3405, in _retrieve_api_key
    xapi.keygen(retry_on_peer=False)
  File "/usr/local/lib/python2.7/site-packages/pandevice/base.py", line 3173, in method
    raise the_exception
pandevice.errors.PanURLError: URLError: reason: [Errno -2] Name or service not known
[~]$ 
[~]$ python dyn_address_group.py -r test 10.24.192.10 admin password 10.6.90.18
[~]$ python dyn_address_group.py -l 10.24.192.10 admin password 10.6.90.18
['test']
[~]$ 
```

Thank you,
Stan