### PR TITLE
Update to StaticRoute class to support using next-vr as a hop type

### DIFF
--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -1306,7 +1306,7 @@ class StaticRoute(VersionedPanObject):
         name (str): The name
         destination (str): Destination network
         nexthop_type (str): ip-address, discard, or next-vr
-        nexthop (str): Next hop IP address
+        nexthop (str): Next hop IP address or Next VR Name
         interface (str): Next hop interface
         admin_dist (str): Administrative distance
         metric (int): Metric (Default: 10)

--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -1305,7 +1305,7 @@ class StaticRoute(VersionedPanObject):
     Args:
         name (str): The name
         destination (str): Destination network
-        nexthop_type (str): ip-address or discard
+        nexthop_type (str): ip-address, discard, or next-vr
         nexthop (str): Next hop IP address
         interface (str): Next hop interface
         admin_dist (str): Administrative distance
@@ -1325,7 +1325,7 @@ class StaticRoute(VersionedPanObject):
             'destination', path='destination'))
         params.append(VersionedParamPath(
             'nexthop_type', default='ip-address',
-            values=['discard', 'ip-address'],
+            values=['discard', 'ip-address', 'next-vr'],
             path='nexthop/{nexthop_type}'))
         params.append(VersionedParamPath(
             'nexthop', path='nexthop/{nexthop_type}'))


### PR DESCRIPTION
I added the next-vr value as an acceptable input type, this was tested against the panos_static_route ansible module, and appears to work appropriately.