### PR TITLE
Fix find_index to compare child.uid with name

### DIFF
--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -1115,7 +1115,7 @@ class PanObject(object):
             class_type = type(self)
 
         for num, child in enumerate(self.children):
-            if ((name is None or self.uid == name)
+            if ((name is None or child.uid == name)
                     and type(child) == class_type):
                 return num
 


### PR DESCRIPTION
Hi,

I found find_index method is not working properly.
Original codes check self.uid with name.
I think comparing child.uid and name is correct way for this method.

`
 for num, child in enumerate(self.children):
            if ((name is None or child.uid == name)
                    and type(child) == class_type):
                return num
`