### PR TITLE
Fix support for "latest" in PanOSVersion for SoftwareUpdater

### DIFF
--- a/pandevice/__init__.py
+++ b/pandevice/__init__.py
@@ -32,7 +32,7 @@ from distutils.version import LooseVersion  # Used by PanOSVersion class
 try:
     import pan
 except ImportError as e:
-    message = e.message + ", please install the pan-python library (pip install pan-python)"
+    message = str(e) + ", please install the pan-python library (pip install pan-python)"
     raise ImportError(message)
 
 # python 2.6 doesn't have a null handler, so create it
@@ -147,6 +147,11 @@ class PanOSVersion(LooseVersion):
         return "PanOSVersion ('%s')" % str(self)
 
     def __lt__(self, other):
+
+        # Handle 'latest' is always higher 
+        if isstring(other) and other == 'latest':
+            return True
+            
         other = stringToVersion(other)
         for (x, y) in zip(self.mainrelease, other.mainrelease):
             if x < y:
@@ -167,6 +172,11 @@ class PanOSVersion(LooseVersion):
         return not self.__lt__(other)
 
     def __eq__(self, other):
+
+        # Handle 'latest' which is always different
+        if isstring(other) and other =='latest':
+            return False
+
         other = stringToVersion(other)
         if self.mainrelease != other.mainrelease:
             return False

--- a/pandevice/updater.py
+++ b/pandevice/updater.py
@@ -376,6 +376,6 @@ class ContentUpdater(Updater):
         if not self.versions:
             self.check()
         # Download the software upgrade
-        self.download(version, sync_to_peer=sync_to_peer, sync=True)
+        self.download(sync_to_peer=sync_to_peer, sync=True)
         # Install the software upgrade
         self.install(version, sync_to_peer=sync_to_peer, skip_commit=skip_commit, sync=sync)


### PR DESCRIPTION
When provided "latest" as target_version in `SoftwareUpdater.upgrade_to_version()`, the execution breaks because `PanOSVersion()` cannot convert the string "latest' to a proper PanOSVersion object, and the following `<` and `==` comparisons break.

Added logic in the `PanOSVersion` class `__lt__` and `__eq__` functions to always consider "latest" as higher and different, respectively, than the current version.

Also changed a couple of lines as suggested by pylint:
- Changed the exception handling of `ImportError` in `__init__` to use `str(e)` instead of `e.message`
- In `ContentUpdater`'s function `download_install()`, `self.download()` is called, but it requires only 2 arguments, not 3 (version is not an argument): removed the wrong argument