### PR TITLE
Fixes #147 - fix set_reference() with templates

### DIFF
--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -1367,18 +1367,73 @@ class PanObject(object):
         elif vartype == "bool":
             return yesno(value)
 
-    def _set_reference(self, reference_name, reference_type, reference_var, exclusive, refresh, update, running_config, *args, **kwargs):
+    def _set_reference(self, reference_name, reference_type, reference_var,
+                       exclusive, refresh, update, running_config,
+                       return_boolean, name_only, **kwargs):
         """Used by helper methods to set references between objects
 
         For example, set_zone() would set the zone for an interface by creating a reference from
         the zone to the interface. If the desired reference already exists then nothing happens.
 
         """
-        device = self.nearest_pandevice()
+        parent = None
+        update_needed = False
+
         if refresh:
-            allobjects = reference_type.refreshall(device, running_config=running_config)
+            from pandevice.firewall import Firewall
+            from pandevice.panorama import Panorama, Template, TemplateStack
+            from pandevice.device import Vsys
+
+            new_tree = None
+            if reference_type.ROOT == Root.VSYS:
+                parent = Vsys(self.vsys or 'vsys1')
+                new_tree = parent
+
+            p = self
+            while p is not None:
+                new_obj = None
+                if isinstance(p, Firewall):
+                    new_obj = Firewall(
+                        hostname=p.hostname,
+                        api_username=p._api_username,
+                        api_password=p._api_password,
+                        api_key=p._api_key,
+                        serial=p.serial,
+                    )
+                elif isinstance(p, Template):
+                    new_obj = Template(p.name)
+                elif isinstance(p, TemplateStack):
+                    new_obj = TemplateStack(p.name)
+                elif isinstance(p, Panorama):
+                    new_obj = Panorama(
+                        hostname=p.hostname,
+                        api_username=p._api_username,
+                        api_password=p._api_password,
+                        api_key=p._api_key,
+                    )
+
+                if new_obj is not None:
+                    if parent is None:
+                        parent = new_obj
+                        new_tree = new_obj
+                    else:
+                        new_obj.add(new_tree)
+                        new_tree = new_obj
+
+                p = p.parent
+
+            if parent is None or isinstance(parent, Panorama):
+                raise err.PanDeviceError('Improper pandevice object tree')
+
+            allobjects = reference_type.refreshall(parent, name_only=name_only,
+                running_config=running_config)
+            if name_only:
+                for obj in allobjects:
+                    obj.refresh_variable(reference_var)
         else:
-            allobjects = device.findall(reference_type)
+            parent = self.nearest_pandevice()
+            allobjects = parent.findall(reference_type)
+
         # Find any current references to self and remove them, unless it is the desired reference
         if exclusive:
             for obj in allobjects:
@@ -1388,35 +1443,46 @@ class PanObject(object):
                 elif hasattr(references, "__iter__") and self in references:
                     if reference_name is not None and str(getattr(obj, reference_type.NAME)) == reference_name:
                         continue
+                    update_needed = True
                     references.remove(self)
                     if update: obj.update(reference_var)
                 elif hasattr(references, "__iter__") and str(self) in references:
                     if reference_name is not None and str(getattr(obj, reference_type.NAME)) == reference_name:
                         continue
+                    update_needed = True
                     references.remove(str(self))
                     if update: obj.update(reference_var)
                 elif references == self or references == str(self):
                     if reference_name is not None and str(getattr(obj, reference_type.NAME)) == reference_name:
                         continue
+                    update_needed = True
                     references = None
                     if update: obj.update(reference_var)
+
         # Add new reference to self in requested object
         if reference_name is not None:
-            obj = device.find_or_create(reference_name, reference_type, *args, **kwargs)
+            obj = parent.find_or_create(reference_name, reference_type, **kwargs)
             var = getattr(obj, reference_var)
             if var is None:
+                update_needed = True
                 setattr(obj, reference_var, [self])
                 if update: obj.update(reference_var)
             elif hasattr(var, "__iter__") and self not in var and str(self) not in var:
+                update_needed = True
                 var.append(self)
                 if update: obj.update(reference_var)
             elif hasattr(var, "__iter__"):
                 # The reference already exists so do nothing
                 pass
             elif var != self and var != str(self):
+                update_needed = True
                 setattr(obj, reference_var, self)
                 if update: obj.update(reference_var)
-            return obj
+            if not return_boolean:
+                return obj
+
+        if return_boolean:
+            return update_needed
 
     def xml_merge(self, root, elements):
         """Merges other elements into the root element.
@@ -2920,7 +2986,8 @@ class VsysOperations(VersionedPanObject):
             device = self.nearest_pandevice()
             device.active().xapi.delete(xpath, retry_on_peer=True)
 
-    def set_vsys(self, vsys_id, refresh=False, update=False, running_config=False):
+    def set_vsys(self, vsys_id, refresh=False, update=False,
+                 running_config=False, return_boolean=False):
         """Set the vsys for this interface.
 
         Creates a reference to this interface in the specified vsys and
@@ -2934,27 +3001,37 @@ class VsysOperations(VersionedPanObject):
             update (bool): Apply the changes to the device (Default: False)
             running_config (bool): If refresh is True, refresh from the running
                 configuration (Default: False)
+            return_boolean (bool): Return a boolean saying if an update
+                is/was needed instead of a Vsys object.
 
         Returns:
             Vsys: The vsys for this interface after the operation completes
 
         """
-        param_name = self.XPATH_IMPORT.split('/')[-1]
+        if refresh and running_config:
+            msg = "Can't refresh vsys from running config in set_vsys"
+            raise ValueError(msg)
 
-        if refresh:
-            if running_config:
-                msg = "Can't refresh vsys from running config in set_vsys"
-                raise ValueError(msg)
+        # Don't import HA or aggregate-group interfaces.
+        if getattr(self, 'mode', '') in ('ha', 'aggregate-group'):
+            return False
 
-            import pandevice.device
-            device = self.nearest_pandevice()
+        import_to_vsys_param = {
+            'vlan': 'vlans',
+            'virtual-wire': 'virtual_wires',
+            'virtual-router': 'virtual_routers',
+            'interface': 'interface',
+        }
+        for key, param_name in import_to_vsys_param.items():
+            if self.XPATH_IMPORT.endswith('/{0}'.format(key)):
+                break
+        else:
+            raise ValueError('Unknown import type: {0}'.format(
+                self.XPATH_IMPORT))
 
-            all_vsys = pandevice.device.Vsys.refreshall(device, name_only=True)
-            for a_vsys in all_vsys:
-                a_vsys.refresh_variable(param_name)
-
-        return self._set_reference(vsys_id, pandevice.device.Vsys, param_name,
-            True, refresh=False, update=update, running_config=running_config)
+        from pandevice.device import Vsys
+        return self._set_reference(vsys_id, Vsys, param_name, True, refresh,
+            update, running_config, return_boolean, True)
 
     @classmethod
     def refreshall(cls, parent, running_config=False, add=True,

--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -286,8 +286,8 @@ class Interface(VsysOperations):
         """
         return self.state == 'up'
 
-    def set_zone(self, zone_name, mode=None, refresh=False,
-                 update=False, running_config=False):
+    def set_zone(self, zone_name, mode=None, refresh=False, update=False,
+                 running_config=False, return_boolean=False):
         """Set the zone for this interface
 
         Creates a reference to this interface in the specified zone and removes
@@ -304,6 +304,8 @@ class Interface(VsysOperations):
             update (bool): Apply the changes to the device (Default: False)
             running_config: If refresh is True, refresh from the running
                 configuration (Default: False)
+            return_boolean (bool): Return a boolean saying if an update
+                is/was needed instead of a Zone object.
 
         Returns:
             Zone: The zone for this interface after the operation completes
@@ -311,12 +313,16 @@ class Interface(VsysOperations):
         """
         if mode is None:
             mode = self.DEFAULT_MODE
+        elif self.vsys == 'shared':
+            return False
 
         return self._set_reference(
             zone_name, Zone, "interface", True, refresh,
-            update, running_config, mode=mode)
+            update, running_config, return_boolean, False, mode=mode)
 
-    def set_virtual_router(self, virtual_router_name, refresh=False, update=False, running_config=False):
+    def set_virtual_router(self, virtual_router_name, refresh=False,
+                           update=False, running_config=False,
+                           return_boolean=False):
         """Set the virtual router for this interface
 
         Creates a reference to this interface in the specified virtual router
@@ -331,17 +337,19 @@ class Interface(VsysOperations):
             update (bool): Apply the changes to the device (Default: False)
             running_config: If refresh is True, refresh from the running
                 configuration (Default: False)
+            return_boolean (bool): Return a boolean saying if an update
+                is/was needed instead of a Zone object.
 
         Returns:
             Zone: The zone for this interface after the operation completes
 
         """
-        return self._set_reference(virtual_router_name, VirtualRouter,
-                                   "interface", True, refresh, update,
-                                   running_config)
+        return self._set_reference(
+            virtual_router_name, VirtualRouter, "interface", True, refresh,
+            update, running_config, return_boolean, False)
 
     def set_vlan(self, vlan_name, refresh=False,
-                 update=False, running_config=False):
+                 update=False, running_config=False, return_boolean=False):
         """Set the vlan for this interface
 
         Creates a reference to this interface in the specified vlan and removes
@@ -356,20 +364,23 @@ class Interface(VsysOperations):
             update (bool): Apply the changes to the device (Default: False)
             running_config: If refresh is True, refresh from the running
                 configuration (Default: False)
+            return_boolean (bool): Return a boolean saying if an update
+                is/was needed instead of a Vlan object.
 
         Raises:
             AttributeError: if this class is not allowed to use this function.
 
         Returns:
-            Zone: The zone for this interface after the operation completes
+            Vlan: The VLAN for this interface after the operation completes
 
         """
         if not self.ALLOW_SET_VLAN:
             msg = 'Class "{0}" cannot invoke this function'
             raise AttributeError(msg.format(self.__class__))
 
-        return self._set_reference(vlan_name, Vlan, "interface", True,
-                                   refresh, update, running_config)
+        return self._set_reference(
+            vlan_name, Vlan, "interface", True,
+            refresh, update, running_config, return_boolean, False)
 
     def get_counters(self):
         """Pull the counters for an interface
@@ -652,7 +663,8 @@ class AbstractSubinterface(object):
         interface.parent = self.parent
         return interface._set_reference(
             virtual_router_name, VirtualRouter, "interface", True,
-            refresh=False, update=update, running_config=running_config)
+            refresh=False, update=update, running_config=running_config,
+            return_boolean=False, name_only=False)
 
     def get_layered_subinterface(self, mode, add=True):
         """Instantiate a regular subinterface type from this AbstractSubinterface
@@ -842,7 +854,7 @@ class PhysicalInterface(Interface):
 
     """
     def set_zone(self, zone_name, mode=None, refresh=False,
-                 update=False, running_config=False):
+                 update=False, running_config=False, return_boolean=False):
         """Set the zone for this interface
 
         Creates a reference to this interface in the specified zone and removes
@@ -859,6 +871,8 @@ class PhysicalInterface(Interface):
             update (bool): Apply the changes to the device (Default: False)
             running_config: If refresh is True, refresh from the running
                 configuration (Default: False)
+            return_boolean (bool): Return a boolean saying if an update
+                is/was needed instead of a Zone object.
 
         Returns:
             Zone: The zone for this interface after the operation completes
@@ -868,7 +882,7 @@ class PhysicalInterface(Interface):
             mode = self.mode
 
         return super(PhysicalInterface, self).set_zone(
-            zone_name, mode, refresh, update, running_config)
+            zone_name, mode, refresh, update, running_config, return_boolean)
 
 
 class EthernetInterface(PhysicalInterface):

--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -287,7 +287,7 @@ class Interface(VsysOperations):
         return self.state == 'up'
 
     def set_zone(self, zone_name, mode=None, refresh=False, update=False,
-                 running_config=False, return_boolean=False):
+                 running_config=False, return_type='object'):
         """Set the zone for this interface
 
         Creates a reference to this interface in the specified zone and removes
@@ -304,8 +304,12 @@ class Interface(VsysOperations):
             update (bool): Apply the changes to the device (Default: False)
             running_config: If refresh is True, refresh from the running
                 configuration (Default: False)
-            return_boolean (bool): Return a boolean saying if an update
-                is/was needed instead of a Zone object.
+            return_type (str): Specify what this function returns, can be
+                either 'object' (the default) or 'bool'.  If this is 'object',
+                then the return value is the Zone in question.  If
+                this is 'bool', then the return value is a boolean that tells
+                you about if the live device needs updates (update=False) or
+                was updated (update=True).
 
         Returns:
             Zone: The zone for this interface after the operation completes
@@ -318,11 +322,11 @@ class Interface(VsysOperations):
 
         return self._set_reference(
             zone_name, Zone, "interface", True, refresh,
-            update, running_config, return_boolean, False, mode=mode)
+            update, running_config, return_type, False, mode=mode)
 
     def set_virtual_router(self, virtual_router_name, refresh=False,
                            update=False, running_config=False,
-                           return_boolean=False):
+                           return_type='object'):
         """Set the virtual router for this interface
 
         Creates a reference to this interface in the specified virtual router
@@ -337,8 +341,12 @@ class Interface(VsysOperations):
             update (bool): Apply the changes to the device (Default: False)
             running_config: If refresh is True, refresh from the running
                 configuration (Default: False)
-            return_boolean (bool): Return a boolean saying if an update
-                is/was needed instead of a Zone object.
+            return_type (str): Specify what this function returns, can be
+                either 'object' (the default) or 'bool'.  If this is 'object',
+                then the return value is the VirtualRouter in question.  If
+                this is 'bool', then the return value is a boolean that tells
+                you about if the live device needs updates (update=False) or
+                was updated (update=True).
 
         Returns:
             Zone: The zone for this interface after the operation completes
@@ -346,10 +354,10 @@ class Interface(VsysOperations):
         """
         return self._set_reference(
             virtual_router_name, VirtualRouter, "interface", True, refresh,
-            update, running_config, return_boolean, False)
+            update, running_config, return_type, False)
 
     def set_vlan(self, vlan_name, refresh=False,
-                 update=False, running_config=False, return_boolean=False):
+                 update=False, running_config=False, return_type='object'):
         """Set the vlan for this interface
 
         Creates a reference to this interface in the specified vlan and removes
@@ -364,8 +372,12 @@ class Interface(VsysOperations):
             update (bool): Apply the changes to the device (Default: False)
             running_config: If refresh is True, refresh from the running
                 configuration (Default: False)
-            return_boolean (bool): Return a boolean saying if an update
-                is/was needed instead of a Vlan object.
+            return_type (str): Specify what this function returns, can be
+                either 'object' (the default) or 'bool'.  If this is 'object',
+                then the return value is the Vlan in question.  If
+                this is 'bool', then the return value is a boolean that tells
+                you about if the live device needs updates (update=False) or
+                was updated (update=True).
 
         Raises:
             AttributeError: if this class is not allowed to use this function.
@@ -380,7 +392,7 @@ class Interface(VsysOperations):
 
         return self._set_reference(
             vlan_name, Vlan, "interface", True,
-            refresh, update, running_config, return_boolean, False)
+            refresh, update, running_config, return_type, False)
 
     def get_counters(self):
         """Pull the counters for an interface
@@ -664,7 +676,7 @@ class AbstractSubinterface(object):
         return interface._set_reference(
             virtual_router_name, VirtualRouter, "interface", True,
             refresh=False, update=update, running_config=running_config,
-            return_boolean=False, name_only=False)
+            return_type='object', name_only=False)
 
     def get_layered_subinterface(self, mode, add=True):
         """Instantiate a regular subinterface type from this AbstractSubinterface
@@ -854,7 +866,7 @@ class PhysicalInterface(Interface):
 
     """
     def set_zone(self, zone_name, mode=None, refresh=False,
-                 update=False, running_config=False, return_boolean=False):
+                 update=False, running_config=False, return_type='object'):
         """Set the zone for this interface
 
         Creates a reference to this interface in the specified zone and removes
@@ -871,8 +883,12 @@ class PhysicalInterface(Interface):
             update (bool): Apply the changes to the device (Default: False)
             running_config: If refresh is True, refresh from the running
                 configuration (Default: False)
-            return_boolean (bool): Return a boolean saying if an update
-                is/was needed instead of a Zone object.
+            return_type (str): Specify what this function returns, can be
+                either 'object' (the default) or 'bool'.  If this is 'object',
+                then the return value is the Zone in question.  If
+                this is 'bool', then the return value is a boolean that tells
+                you about if the live device needs updates (update=False) or
+                was updated (update=True).
 
         Returns:
             Zone: The zone for this interface after the operation completes
@@ -882,7 +898,7 @@ class PhysicalInterface(Interface):
             mode = self.mode
 
         return super(PhysicalInterface, self).set_zone(
-            zone_name, mode, refresh, update, running_config, return_boolean)
+            zone_name, mode, refresh, update, running_config, return_type)
 
 
 class EthernetInterface(PhysicalInterface):

--- a/tests/live/test_set_reference.py
+++ b/tests/live/test_set_reference.py
@@ -1,0 +1,675 @@
+import pytest
+
+from pandevice.device import Vsys
+from pandevice.firewall import Firewall
+from pandevice.network import EthernetInterface
+from pandevice.network import VirtualRouter
+from pandevice.network import VirtualWire
+from pandevice.network import Vlan
+from pandevice.network import Zone
+from pandevice.panorama import Panorama
+from pandevice.panorama import Template
+
+from tests.live import testlib
+
+
+class VsysImport(object):
+    CLASS = None
+    VSYS_PARAM = None
+
+    def sanity(self, dev, state_map, fw_test=False):
+        state = state_map.setdefault(dev)
+        if state.err:
+            state.fail_func('prereq failed')
+
+        if fw_test:
+            if not isinstance(dev, Firewall):
+                pytest.skip('Skipping firewall-only test')
+            dev.removeall()
+            dev.add(state.obj)
+            vsys_list = Vsys.refreshall(dev, name_only=True)
+            for v in vsys_list:
+                v.refresh_variable(self.VSYS_PARAM)
+
+        return state
+
+    def assert_imported_into(self, vsys, state):
+        found = False
+
+        vsys_list = Vsys.refreshall(state.parent, add=False, name_only=True)
+        for v in vsys_list:
+            v.refresh_variable(self.VSYS_PARAM)
+            if getattr(v, self.VSYS_PARAM) is None:
+                setattr(v, self.VSYS_PARAM, [])
+            if vsys == v.name:
+                found = True
+                assert state.name in getattr(v, self.VSYS_PARAM)
+            else:
+                assert state.name not in getattr(v, self.VSYS_PARAM)
+
+        if vsys is not None:
+            assert found
+
+    def test_01_setup(self, dev, state_map):
+        state = state_map.setdefault(dev)
+        state.err = True
+        state.fail_func = pytest.skip
+        state.parent = dev
+        state.name = None
+        state.delete_parent = False
+        state.obj = None
+
+        if self.CLASS is None:
+            pytest.skip('{0}.CLASS must be defined'.format(
+                        self.__class__.__name__))
+        elif self.VSYS_PARAM is None:
+            pytest.skip('{0}.VSYS_PARAM must be defined'.format(
+                        self.__class__.__name__))
+
+        if isinstance(state.parent, Panorama):
+            tmpl = Template(testlib.random_name())
+            state.parent.add(tmpl)
+            state.parent = tmpl
+            state.parent.add(Vsys('vsys1'))
+            state.parent.add(Vsys('vsys2'))
+            state.parent.add(Vsys('vsys3'))
+            state.parent.create()
+            state.delete_parent = True
+        else:
+            vsys_list = [x.name for x in Vsys.refreshall(dev, add=False, name_only=True)]
+            if not all('vsys{0}'.format(x) in vsys_list for x in range(1, 4)):
+                pytest.skip('Firewall needs vsys1 - vsys3 to exist')
+
+        args = {}
+        if self.CLASS == EthernetInterface:
+            state.name = testlib.get_available_interfaces(state.parent)[0]
+            args = {'mode': 'layer3'}
+        else:
+            state.name = testlib.random_name()
+        state.obj = self.CLASS(state.name, **args)
+        state.parent.add(state.obj)
+        state.err = False
+
+    def test_02_create(self, dev, state_map):
+        state = self.sanity(dev, state_map)
+
+        state.err = True
+        state.fail_func = pytest.xfail
+        state.obj.create()
+        state.err = False
+
+    def test_03_vsys2_object_rt(self, dev, state_map):
+        v = 'vsys2'
+        state = self.sanity(dev, state_map)
+
+        ans = state.obj.set_vsys(v, refresh=True, update=True)
+
+        assert isinstance(ans, Vsys)
+        assert ans.name == v
+        self.assert_imported_into(v, state)
+
+    def test_04_update_false_does_not_update_object_rt(self, dev, state_map):
+        v = 'vsys2'
+        other_v = 'vsys3'
+        state = self.sanity(dev, state_map)
+
+        ans = state.obj.set_vsys(other_v, refresh=True, update=False)
+
+        assert isinstance(ans, Vsys)
+        assert ans.name == other_v
+        self.assert_imported_into(v, state)
+
+    def test_05_import_into_lower_vsys_object_rt(self, dev, state_map):
+        v = 'vsys1'
+        state = self.sanity(dev, state_map)
+
+        ans = state.obj.set_vsys(v, refresh=True, update=True)
+
+        assert isinstance(ans, Vsys)
+        assert ans.name == v
+        self.assert_imported_into(v, state)
+
+    def test_06_import_into_higher_vsys_object_rt(self, dev, state_map):
+        v = 'vsys3'
+        state = self.sanity(dev, state_map)
+
+        ans = state.obj.set_vsys(v, refresh=True, update=True)
+
+        assert isinstance(ans, Vsys)
+        assert ans.name == v
+        self.assert_imported_into(v, state)
+
+    def test_07_import_into_current_vsys_object_rt(self, dev, state_map):
+        v = 'vsys3'
+        state = self.sanity(dev, state_map)
+
+        ans = state.obj.set_vsys(v, refresh=True, update=True)
+
+        assert isinstance(ans, Vsys)
+        assert ans.name == v
+        self.assert_imported_into(v, state)
+
+    def test_08_unimport_object_rt(self, dev, state_map):
+        state = self.sanity(dev, state_map)
+
+        ans = state.obj.set_vsys(None, refresh=True, update=True)
+
+        assert ans is None
+        self.assert_imported_into(None, state)
+
+    def test_09_unimport_when_unimported_object_rt(self, dev, state_map):
+        state = self.sanity(dev, state_map)
+
+        ans = state.obj.set_vsys(None, refresh=True, update=True)
+
+        assert ans is None
+        self.assert_imported_into(None, state)
+
+    def test_10_vsys2_bool_rt(self, dev, state_map):
+        v = 'vsys2'
+        state = self.sanity(dev, state_map)
+
+        ans = state.obj.set_vsys(v, refresh=True, update=True, return_type='bool')
+
+        assert isinstance(ans, bool)
+        assert ans
+        self.assert_imported_into(v, state)
+
+    def test_11_already_in_correct_vsys_bool_rt(self, dev, state_map):
+        v = 'vsys2'
+        state = self.sanity(dev, state_map)
+
+        ans = state.obj.set_vsys(v, refresh=True, update=True, return_type='bool')
+
+        assert isinstance(ans, bool)
+        assert not ans
+        self.assert_imported_into(v, state)
+
+    def test_12_same_vsys_no_update_bool_rt(self, dev, state_map):
+        v = 'vsys2'
+        state = self.sanity(dev, state_map)
+
+        ans = state.obj.set_vsys(v, refresh=True, update=False, return_type='bool')
+
+        assert isinstance(ans, bool)
+        assert not ans
+        self.assert_imported_into(v, state)
+
+    def test_13_different_vsys_no_update_bool_rt(self, dev, state_map):
+        v = 'vsys2'
+        state = self.sanity(dev, state_map)
+
+        ans = state.obj.set_vsys('vsys1', refresh=True, update=False, return_type='bool')
+
+        assert isinstance(ans, bool)
+        assert ans
+        self.assert_imported_into(v, state)
+
+    def test_20_setup_for_classic_tests(self, dev, state_map):
+        state = self.sanity(dev, state_map)
+
+        ans = state.obj.set_vsys(None, refresh=True, update=True)
+
+        assert ans is None
+        self.assert_imported_into(None, state)
+
+    def test_21_classic_import_object_rt(self, dev, state_map):
+        v = 'vsys1'
+        state = self.sanity(dev, state_map, True)
+
+        ans = state.obj.set_vsys(v, refresh=False, update=True)
+
+        assert isinstance(ans, Vsys)
+        assert ans.name == v
+        assert state.name in [str(x) for x in getattr(ans, self.VSYS_PARAM)]
+        self.assert_imported_into(v, state)
+
+    def test_22_classic_import_noop_object_rt(self, dev, state_map):
+        v = 'vsys1'
+        state = self.sanity(dev, state_map, True)
+
+        ans = state.obj.set_vsys(v, refresh=False, update=True)
+
+        assert isinstance(ans, Vsys)
+        assert ans.name == v
+        assert state.name in [str(x) for x in getattr(ans, self.VSYS_PARAM)]
+        self.assert_imported_into(v, state)
+
+    def test_23_classic_import_no_update_object_rt(self, dev, state_map):
+        v = 'vsys1'
+        other_v = 'vsys2'
+        state = self.sanity(dev, state_map, True)
+
+        ans = state.obj.set_vsys(other_v, refresh=False, update=False)
+
+        assert isinstance(ans, Vsys)
+        assert ans.name == other_v
+        assert state.name in [str(x) for x in getattr(ans, self.VSYS_PARAM)]
+        self.assert_imported_into(v, state)
+
+    def test_24_classic_import_higher_vsys_object_rt(self, dev, state_map):
+        v = 'vsys3'
+        state = self.sanity(dev, state_map, True)
+
+        ans = state.obj.set_vsys(v, refresh=False, update=True)
+
+        previous_vsys = dev.find('vsys1')
+        assert isinstance(ans, Vsys)
+        assert ans.name == v
+        assert state.name in [str(x) for x in getattr(ans, self.VSYS_PARAM)]
+        assert previous_vsys is not None
+        assert state.name not in [str(x) for x in (getattr(previous_vsys, self.VSYS_PARAM) or [])]
+        self.assert_imported_into(v, state)
+
+    def test_25_classic_import_lower_vsys_object_rt(self, dev, state_map):
+        v = 'vsys2'
+        state = self.sanity(dev, state_map, True)
+
+        ans = state.obj.set_vsys(v, refresh=False, update=True)
+
+        previous_vsys = dev.find('vsys3')
+        assert isinstance(ans, Vsys)
+        assert ans.name == v
+        assert state.name in [str(x) for x in getattr(ans, self.VSYS_PARAM)]
+        assert previous_vsys is not None
+        assert state.name not in [str(x) for x in (getattr(previous_vsys, self.VSYS_PARAM) or [])]
+        self.assert_imported_into(v, state)
+
+    def test_26_classic_import_unimport_object_rt(self, dev, state_map):
+        state = self.sanity(dev, state_map, True)
+
+        ans = state.obj.set_vsys(None, refresh=False, update=True)
+
+        previous_vsys = dev.find('vsys2')
+        assert ans is None
+        assert previous_vsys is not None
+        assert state.name not in (getattr(previous_vsys, self.VSYS_PARAM) or [])
+        self.assert_imported_into(None, state)
+
+    def test_27_classic_import_unimport_when_unimported_object_rt(self, dev, state_map):
+        state = self.sanity(dev, state_map, True)
+
+        ans = state.obj.set_vsys(None, refresh=False, update=True)
+
+        assert ans is None
+        self.assert_imported_into(None, state)
+
+    def test_98_cleanup_dependencies(self, dev, state_map):
+        state = state_map.setdefault(dev)
+
+        if state.delete_parent:
+            try:
+                state.parent.delete()
+            except Exception:
+                pass
+        else:
+            try:
+                state.obj.delete()
+            except Exception:
+                pass
+
+    def test_99_removeall(self, dev, state_map):
+        dev.removeall()
+
+
+class TestInterfaceImport(VsysImport):
+    CLASS = EthernetInterface
+    VSYS_PARAM = 'interface'
+
+
+class TestVirtualRouterImport(VsysImport):
+    CLASS = VirtualRouter
+    VSYS_PARAM = 'virtual_routers'
+
+
+class TestVlanImport(VsysImport):
+    CLASS = Vlan
+    VSYS_PARAM = 'vlans'
+
+
+class TestVirtualWireImport(VsysImport):
+    CLASS = VirtualWire
+    VSYS_PARAM = 'virtual_wires'
+
+
+class PlaceInterface(object):
+    FUNC = None
+    CLASS = None
+    PARAM = None
+
+    def sanity(self, dev, state_map, fw_test=False):
+        state = state_map.setdefault(dev)
+        if state.err:
+            state.fail_func('prereq failed')
+
+        if fw_test:
+            if not isinstance(dev, Firewall):
+                pytest.skip('skipping firewall-only test')
+            if self.CLASS != Zone:
+                dev.vsys = None
+            self.CLASS.refreshall(dev)
+
+        if state.tmpl is None:
+            dev.vsys = 'vsys2'
+
+        return state
+
+    def assert_placement(self, name, dev, state):
+        found = False
+
+        if state.tmpl is None and self.CLASS != Zone:
+            dev.vsys = None
+
+        obj_list = self.CLASS.refreshall(state.parent, add=False)
+        for o in obj_list:
+            if getattr(o, self.PARAM) is None:
+                setattr(o, self.PARAM, [])
+            if o.name == name:
+                found = True
+                assert state.name in getattr(o, self.PARAM)
+            else:
+                assert state.name not in getattr(o, self.PARAM)
+
+        if name is not None:
+            assert found
+
+    def test_01_setup(self, dev, state_map):
+        state = state_map.setdefault(dev)
+        state.err = True
+        state.fail_func = pytest.skip
+        state.parent = dev
+        state.tmpl = None
+        state.name = None
+        state.obj = None
+        state.targets = [testlib.random_name() for x in range(2)]
+
+        if self.FUNC is None:
+            pytest.skip('{0}.FUNC must be defined'.format(
+                        self.__class__.__name__))
+        elif self.CLASS is None:
+            pytest.skip('{0}.CLASS must be defined'.format(
+                        self.__class__.__name__))
+        elif self.PARAM is None:
+            pytest.skip('{0}.PARAM must be defined'.format(
+                        self.__class__.__name__))
+
+        if isinstance(state.parent, Panorama):
+            tmpl = Template(testlib.random_name())
+            state.parent.add(tmpl)
+            v = Vsys('vsys2')
+            tmpl.add(v)
+            state.parent = v
+            tmpl.create()
+            state.tmpl = tmpl
+        else:
+            vsys_list = [x.name for x in Vsys.refreshall(dev, add=False, name_only=True)]
+            if 'vsys2' not in vsys_list:
+                pytest.skip('Firewall needs vsys2 to exist')
+
+        cls_args = {}
+        eth_args = {'mode': 'layer3'}
+        if self.CLASS == Vlan:
+            eth_args['mode'] = 'layer2'
+        elif self.CLASS == Zone:
+            cls_args['mode'] = 'layer3'
+
+        state.name = testlib.get_available_interfaces(state.parent)[0]
+        state.obj = EthernetInterface(state.name, **eth_args)
+        state.parent.add(state.obj)
+
+        if state.tmpl is None:
+            dev.vsys = 'vsys2'
+
+        instances = [self.CLASS(state.targets[x], **cls_args) for x in range(2)]
+        for x in instances:
+            state.parent.add(x)
+            x.create()
+
+        state.err = False
+
+    def test_02_create(self, dev, state_map):
+        state = self.sanity(dev, state_map)
+
+        state.err = True
+        state.fail_func = pytest.xfail
+        state.obj.create()
+        state.obj.set_vsys('vsys2', refresh=True, update=True)
+        state.err = False
+
+    def test_03_set_no_priors_object_rt(self, dev, state_map):
+        i = 0
+        state = self.sanity(dev, state_map)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[i], refresh=True, update=True)
+
+        assert isinstance(ans, self.CLASS)
+        assert ans.name == state.targets[i]
+        self.assert_placement(state.targets[i], dev, state)
+
+    def test_04_update_false_does_not_update_object_rt(self, dev, state_map):
+        state = self.sanity(dev, state_map)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[1], refresh=True, update=False)
+
+        assert isinstance(ans, self.CLASS)
+        assert ans.name == state.targets[1]
+        self.assert_placement(state.targets[0], dev, state)
+
+    def test_05_change_forward_object_rt(self, dev, state_map):
+        i = 1
+        state = self.sanity(dev, state_map)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[i], refresh=True, update=True)
+
+        assert isinstance(ans, self.CLASS)
+        assert ans.name == state.targets[i]
+        self.assert_placement(state.targets[i], dev, state)
+
+    def test_06_change_backward_object_rt(self, dev, state_map):
+        i = 0
+        state = self.sanity(dev, state_map)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[i], refresh=True, update=True)
+
+        assert isinstance(ans, self.CLASS)
+        assert ans.name == state.targets[i]
+        self.assert_placement(state.targets[i], dev, state)
+
+    def test_07_change_to_current_object_rt(self, dev, state_map):
+        i = 0
+        state = self.sanity(dev, state_map)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[i], refresh=True, update=True)
+
+        assert isinstance(ans, self.CLASS)
+        assert ans.name == state.targets[i]
+        self.assert_placement(state.targets[i], dev, state)
+
+    def test_08_remove_object_rt(self, dev, state_map):
+        state = self.sanity(dev, state_map)
+
+        ans = getattr(state.obj, self.FUNC)(None, refresh=True, update=True)
+
+        assert ans is None
+        self.assert_placement(None, dev, state)
+
+    def test_09_remove_when_not_present_object_rt(self, dev, state_map):
+        state = self.sanity(dev, state_map)
+
+        ans = getattr(state.obj, self.FUNC)(None, refresh=True, update=True)
+
+        assert ans is None
+        self.assert_placement(None, dev, state)
+
+    def test_10_change_bool_rt(self, dev, state_map):
+        i = 0
+        state = self.sanity(dev, state_map)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[i], refresh=True, update=True, return_type='bool')
+
+        assert isinstance(ans, bool)
+        assert ans
+        self.assert_placement(state.targets[i], dev, state)
+
+    def test_11_in_place_bool_rt(self, dev, state_map):
+        i = 0
+        state = self.sanity(dev, state_map)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[i], refresh=True, update=True, return_type='bool')
+
+        assert isinstance(ans, bool)
+        assert not ans
+        self.assert_placement(state.targets[i], dev, state)
+
+    def test_12_same_spot_no_update_bool_rt(self, dev, state_map):
+        i = 0
+        state = self.sanity(dev, state_map)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[i], refresh=True, update=False, return_type='bool')
+
+        assert isinstance(ans, bool)
+        assert not ans
+        self.assert_placement(state.targets[i], dev, state)
+
+    def test_13_different_spot_no_update_bool_rt(self, dev, state_map):
+        state = self.sanity(dev, state_map)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[1], refresh=True, update=False, return_type='bool')
+
+        assert isinstance(ans, bool)
+        assert ans
+        self.assert_placement(state.targets[0], dev, state)
+
+    def test_20_setup_for_classic_tests(self, dev, state_map):
+        state = self.sanity(dev, state_map)
+
+        ans = getattr(state.obj, self.FUNC)(None, refresh=True, update=True)
+
+        assert ans is None
+        self.assert_placement(None, dev, state)
+
+    def test_21_classic_placement_object_rt(self, dev, state_map):
+        i = 0
+        state = self.sanity(dev, state_map, True)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[i], refresh=False, update=True)
+
+        assert isinstance(ans, self.CLASS)
+        assert ans.name == state.targets[i]
+        assert state.name in [str(x) for x in getattr(ans, self.PARAM)]
+        self.assert_placement(state.targets[i], dev, state)
+
+    def test_22_classic_noop_object_rt(self, dev, state_map):
+        i = 0
+        state = self.sanity(dev, state_map, True)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[i], refresh=False, update=True)
+
+        assert isinstance(ans, self.CLASS)
+        assert ans.name == state.targets[i]
+        assert state.name in [str(x) for x in getattr(ans, self.PARAM)]
+        self.assert_placement(state.targets[i], dev, state)
+
+    def test_23_classic_no_update_object_rt(self, dev, state_map):
+        state = self.sanity(dev, state_map, True)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[1], refresh=False, update=False)
+
+        assert isinstance(ans, self.CLASS)
+        assert ans.name == state.targets[1]
+        assert state.name in [str(x) for x in getattr(ans, self.PARAM)]
+        self.assert_placement(state.targets[0], dev, state)
+
+    def test_24_classic_placement_move_forward_object_rt(self, dev, state_map):
+        i = 1
+        state = self.sanity(dev, state_map, True)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[i], refresh=False, update=True)
+
+        prev_obj = state.parent.find(state.targets[0])
+        assert isinstance(ans, self.CLASS)
+        assert ans.name == state.targets[i]
+        assert state.name in [str(x) for x in getattr(ans, self.PARAM)]
+        assert prev_obj is not None
+        assert state.name not in [str(x) for x in (getattr(prev_obj, self.PARAM) or [])]
+        self.assert_placement(state.targets[i], dev, state)
+
+    def test_25_classic_placement_move_backward_object_rt(self, dev, state_map):
+        i = 0
+        state = self.sanity(dev, state_map, True)
+
+        ans = getattr(state.obj, self.FUNC)(state.targets[i], refresh=False, update=True)
+
+        prev_obj = state.parent.find(state.targets[1])
+        assert isinstance(ans, self.CLASS)
+        assert ans.name == state.targets[i]
+        assert state.name in [str(x) for x in getattr(ans, self.PARAM)]
+        assert prev_obj is not None
+        assert state.name not in [str(x) for x in (getattr(prev_obj, self.PARAM) or [])]
+        self.assert_placement(state.targets[i], dev, state)
+
+    def test_26_classic_remove_object_rt(self, dev, state_map):
+        state = self.sanity(dev, state_map, True)
+
+        ans = getattr(state.obj, self.FUNC)(None, refresh=False, update=True)
+
+        prev_obj = state.parent.find(state.targets[0])
+        assert ans is None
+        assert prev_obj is not None
+        assert state.name not in [str(x) for x in (getattr(prev_obj, self.PARAM) or [])]
+        self.assert_placement(None, dev, state)
+
+    def test_27_classic_remove_when_already_removed_object_rt(self, dev, state_map):
+        state = self.sanity(dev, state_map, True)
+
+        ans = getattr(state.obj, self.FUNC)(None, refresh=False, update=True)
+
+        assert ans is None
+        self.assert_placement(None, dev, state)
+
+    def test_98_cleanup_dependencies(self, dev, state_map):
+        state = self.sanity(dev, state_map)
+
+        if state.tmpl is not None:
+            try:
+                state.tmpl.delete()
+            except Exception:
+                pass
+        else:
+            if self.CLASS != Zone:
+                dev.vsys = None
+            instances = self.CLASS.refreshall(dev, name_only=True)
+            dev.vsys = 'vsys2'
+            for o in instances:
+                if o.name in state.targets:
+                    try:
+                        o.delete()
+                    except Exception:
+                        pass
+            try:
+                state.obj.delete()
+            except Exception:
+                pass
+            if dev.vsys is not None:
+                dev.vsys = None
+
+    def test_99_removeall(self, dev, state_map):
+        dev.removeall()
+
+
+class TestVirtualRouterPlacement(PlaceInterface):
+    FUNC = 'set_virtual_router'
+    CLASS = VirtualRouter
+    PARAM = 'interface'
+
+
+class TestVlanPlacement(PlaceInterface):
+    FUNC = 'set_vlan'
+    CLASS = Vlan
+    PARAM = 'interface'
+
+
+class TestZonePlacement(PlaceInterface):
+    FUNC = 'set_zone'
+    CLASS = Zone
+    PARAM = 'interface'


### PR DESCRIPTION
Few other updates:

* Adds a new flag, `return_boolean`, that the Ansible modules will need
* Fixes `set_vsys()` for VLANs, virtual wires, and virtual routers (only interface imports worked)