### PR TITLE
Updated to include admin specific commit option

### DIFF
--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -4262,7 +4262,7 @@ class PanDevice(PanObject):
                         admin_xml.text = admin
                 if exclude is not None:
                     excluded = ET.SubElement(partial, exclude)
-                cmd = ET.tostring(cmd, encoding='utf-8')
+            cmd = ET.tostring(cmd, encoding='utf-8')
           
         logger.debug(self.id + ": commit requested: commit_all:%s sync:%s sync_all:%s cmd:%s" % (str(commit_all),
                                                                                                        str(sync),


### PR DESCRIPTION
Updated commit method to accept an admin account name or list of admin accounts to utilize partial admin commit functionality in PanOS 8.0+.