### PR TITLE
Added peer-ip-backup to ha.HighAvailability and updated test

### DIFF
--- a/pandevice/ha.py
+++ b/pandevice/ha.py
@@ -278,6 +278,7 @@ class HighAvailability(VersionedPanObject):
         description (str): Description for HA pairing
         config_sync (bool): Enabled configuration synchronization (Default: True)
         peer_ip (str): HA Peer's HA1 IP address
+        peer_ip_backup (str): HA Peer's HA1 backup IP address
         mode (str): Mode of HA: 'active-passive' or 'active-active' (Default: 'active-passive')
         passive_link_state (str): Passive link state
         state_sync (bool): Enabled state synchronization (Default: False)
@@ -331,9 +332,14 @@ class HighAvailability(VersionedPanObject):
             path='group/configuration-synchronization/enabled')
         params.append(VersionedParamPath(
             'peer_ip', path='group/entry group_id/peer-ip'))
+        params.append(VersionedParamPath(
+            'peer_ip_backup', path='group/entry group_id/peer-ip-backup'))
         params[-1].add_profile(
             '8.1.0',
             path='group/peer-ip')
+        params[-1].add_profile(
+            '8.1.0',
+            path='group/peer-ip-backup')
         params.append(VersionedParamPath(
             'mode', default='active-passive',
             values=('active-passive', 'active-active'),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -158,6 +158,7 @@ class TestElementStr_7_0(unittest.TestCase):
             b'<description>my ha conf description</description>',
             b'<configuration-synchronization><enabled>yes</enabled>',
             b'</configuration-synchronization><peer-ip>10.5.1.5</peer-ip>',
+            b'<peer-ip-backup>10.6.1.5</peer-ip-backup>',
             b'<mode><active-passive><passive-link-state>passive state',
             b'</passive-link-state></active-passive></mode>',
             b'<state-synchronization><enabled>no</enabled><ha2-keep-alive>',
@@ -184,7 +185,7 @@ class TestElementStr_7_0(unittest.TestCase):
             link_duplex='auto')
         ha_config = pandevice.ha.HighAvailability(
             'my high availability config', True, '1', 'my ha conf description',
-            True, '10.5.1.5', 'active-passive', 'passive state', False, True,
+            True, '10.5.1.5', '10.6.1.5', 'active-passive', 'passive state', False, True,
             'ha2 do stuff', 2)
 
         ha_config.add(h1o)


### PR DESCRIPTION
Added the missing peer-ip-backup to ha.HighAvailability class.  This is pretty important for standard redundant HA setups.

tox failed before I changed any code.  Flake8 had issues before as well.  All unit tests passed after I updated test_integration.py with new argument to ha.HighAvailability object creation.