### PR TITLE
Add ScheduleObject to objects.py, device.py, firewall.py, and panoram…

### DIFF
--- a/pandevice/device.py
+++ b/pandevice/device.py
@@ -115,6 +115,7 @@ class Vsys(VersionedPanObject):
         "objects.ApplicationObject",
         "objects.ApplicationGroup",
         "objects.ApplicationFilter",
+        "objects.ScheduleObject",
         "objects.SecurityProfileGroup",
         "objects.CustomUrlCategory",
         "objects.LogForwardingProfile",

--- a/pandevice/firewall.py
+++ b/pandevice/firewall.py
@@ -80,6 +80,7 @@ class Firewall(PanDevice):
         "objects.ApplicationObject",
         "objects.ApplicationGroup",
         "objects.ApplicationFilter",
+        "objects.ScheduleObject",
         "objects.SecurityProfileGroup",
         "objects.CustomUrlCategory",
         "objects.LogForwardingProfile",

--- a/pandevice/objects.py
+++ b/pandevice/objects.py
@@ -734,3 +734,74 @@ class DynamicUserGroup(VersionedPanObject):
             'tag', path='tag', vartype='member'))
 
         self._params = tuple(params)
+
+
+class ScheduleObject(VersionedPanObject):
+    """Schedule Object
+
+    "Date and Time Range" Example:  2019/11/01@00:15-2019/11/28@00:30
+    "Time Range" Example:  17:00-19:00
+
+    Args:
+        name (str): Name of the object
+        disable_override (bool): "True" to set disable-override
+        type (str): Type of Schedule: "recurring" or "non-recurring"
+        non_recurring_date_time (list/str): "Date and Time Range" string for a non-recurring schedule
+        recurrence (str): "daily" or "weekly" recurrence
+        daily_time (list/str): "Time Range" for a daily recurring schedule
+        weekly_sunday_time (list/str): "Time Range" for a weekly recurring schedule (Sunday)
+        weekly_monday_time (list/str): "Time Range" for a weekly recurring schedule (Monday)
+        weekly_tuesday_time (list/str): "Time Range" for a weekly recurring schedule (Tuesday)
+        weekly_wednesday_time (list/str): "Time Range" for a weekly recurring schedule (Wednesday)
+        weekly_thursday_time (list/str): "Time Range" for a weekly recurring schedule (Thursday)
+        weekly_friday_time (list/str): "Time Range" for a weekly recurring schedule (Friday)
+        weekly_saturday_time (list/str): "Time Range" for a weekly recurring schedule (Saturday)
+
+    """
+    ROOT = Root.VSYS
+    SUFFIX = ENTRY
+
+    def _setup(self):
+        # xpaths
+        self._xpaths.add_profile(value='/schedule')
+
+        # params
+        params = []
+
+        params.append(VersionedParamPath(
+            'disable_override', vartype='yesno', path='disable-override'))
+        params.append(VersionedParamPath(
+            'type', path='schedule-type/{type}',
+            values=['recurring', 'non-recurring']))
+        params.append(VersionedParamPath(
+            'non_recurring_date_time', path='schedule-type/{type}', vartype='member',
+            condition={'type': 'non-recurring'}))
+        params.append(VersionedParamPath(
+            'recurrence', path='schedule-type/{type}/{recurrence}', values=['weekly', 'daily'],
+            condition={'type': 'recurring'}))
+        params.append(VersionedParamPath(
+            'daily_time', path='schedule-type/{type}/{recurrence}', vartype='member',
+            condition={'type': 'recurring', 'recurrence': 'daily'}))
+        params.append(VersionedParamPath(
+            'weekly_sunday_time', path='schedule-type/{type}/{recurrence}/sunday', vartype='member',
+            condition={'type': 'recurring', 'recurrence': 'weekly'}))
+        params.append(VersionedParamPath(
+            'weekly_monday_time', path='schedule-type/{type}/{recurrence}/monday', vartype='member',
+            condition={'type': 'recurring', 'recurrence': 'weekly'}))
+        params.append(VersionedParamPath(
+            'weekly_tuesday_time', path='schedule-type/{type}/{recurrence}/tuesday', vartype='member',
+            condition={'type': 'recurring', 'recurrence': 'weekly'}))
+        params.append(VersionedParamPath(
+            'weekly_wednesday_time', path='schedule-type/{type}/{recurrence}/wednesday', vartype='member',
+            condition={'type': 'recurring', 'recurrence': 'weekly'}))
+        params.append(VersionedParamPath(
+            'weekly_thursday_time', path='schedule-type/{type}/{recurrence}/thursday', vartype='member',
+            condition={'type': 'recurring', 'recurrence': 'weekly'}))
+        params.append(VersionedParamPath(
+            'weekly_friday_time', path='schedule-type/{type}/{recurrence}/friday', vartype='member',
+            condition={'type': 'recurring', 'recurrence': 'weekly'}))
+        params.append(VersionedParamPath(
+            'weekly_saturday_time', path='schedule-type/{type}/{recurrence}/saturday', vartype='member',
+            condition={'type': 'recurring', 'recurrence': 'weekly'}))
+
+        self._params = tuple(params)

--- a/pandevice/panorama.py
+++ b/pandevice/panorama.py
@@ -63,6 +63,7 @@ class DeviceGroup(VersionedPanObject):
         "objects.ApplicationObject",
         "objects.ApplicationGroup",
         "objects.ApplicationFilter",
+        "objects.ScheduleObject",
         "objects.SecurityProfileGroup",
         "objects.CustomUrlCategory",
         "objects.LogForwardingProfile",


### PR DESCRIPTION
Created a ScheduleObject class in objects.py to manage Schedules that are attached to firewall policies.  

## Description

Schedule Object

    "Date and Time Range" Example:  2019/11/01@00:15-2019/11/28@00:30
    "Time Range" Example:  17:00-19:00

    Args:
        name (str): Name of the object
        disable_override (bool): "True" to set disable-override
        type (str): Type of Schedule: "recurring" or "non-recurring"
        non_recurring_date_time (list/str): "Date and Time Range" string for a non-recurring schedule
        recurrence (str): "daily" or "weekly" recurrence
        daily_time (list/str): "Time Range" for a daily recurring schedule
        weekly_sunday_time (list/str): "Time Range" for a weekly recurring schedule (Sunday)
        weekly_monday_time (list/str): "Time Range" for a weekly recurring schedule (Monday)
        weekly_tuesday_time (list/str): "Time Range" for a weekly recurring schedule (Tuesday)
        weekly_wednesday_time (list/str): "Time Range" for a weekly recurring schedule (Wednesday)
        weekly_thursday_time (list/str): "Time Range" for a weekly recurring schedule (Thursday)
        weekly_friday_time (list/str): "Time Range" for a weekly recurring schedule (Friday)
        weekly_saturday_time (list/str): "Time Range" for a weekly recurring schedule (Saturday)



## Motivation and Context

Adds the functionality requested in Enhancement request #188 

## How Has This Been Tested?

This enhancement has been tested against a Development Panorama VM running 8.1.8 code. 

set device-group DG_Bottom schedule AfterHours schedule-type recurring daily [ 17:00-19:00 20:00-23:59 ]
set device-group DG_Bottom schedule NonRecur schedule-type non-recurring 2019/11/01@00:15-2019/11/28@00:30
set device-group DG_Bottom schedule DisableOverride disable-override yes
set device-group DG_Bottom schedule DisableOverride schedule-type recurring weekly sunday 11:00-13:00
set device-group DG_Bottom schedule DisableOverride schedule-type recurring weekly tuesday 11:00-13:00

The output of the .about() function from the above config:

{'disable_override': None, 'type': 'recurring', 'non_recurring_date_time': [], 'recurrence': 'daily', 'daily_time': ['17:00-19:00', '20:00-23:59'], 'weekly_sunday_time': None, 'weekly_monday_time': None, 'weekly_tuesday_time': None, 'weekly_wednesday_time': None, 'weekly_thursday_time': None, 'weekly_friday_time': None, 'weekly_saturday_time': None, 'name': 'AfterHours'}

{'disable_override': None, 'type': 'non-recurring', 'non_recurring_date_time': ['2019/11/01@00:15-2019/11/28@00:30'], 'recurrence': None, 'daily_time': None, 'weekly_sunday_time': None, 'weekly_monday_time': None, 'weekly_tuesday_time': None, 'weekly_wednesday_time': None, 'weekly_thursday_time': None, 'weekly_friday_time': None, 'weekly_saturday_time': None, 'name': 'NonRecur'}

{'disable_override': True, 'type': 'recurring', 'non_recurring_date_time': [], 'recurrence': 'weekly', 'daily_time': None, 'weekly_sunday_time': ['11:00-13:00'], 'weekly_monday_time': None, 'weekly_tuesday_time': ['11:00-13:00'], 'weekly_wednesday_time': None, 'weekly_thursday_time': None, 'weekly_friday_time': None, 'weekly_saturday_time': None, 'name': 'DisableOverride'}

## Screenshots (if appropriate)

<!--- Drag any screenshots here -->

## Types of changes

<!--- What types of changes does your code introduce? -->

<!--- Remove any that don't apply: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
