### PR TITLE
base: inherit port number when set reference in refresh mode

### DIFF
--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -1447,6 +1447,7 @@ class PanObject(object):
                 if isinstance(p, Firewall):
                     new_obj = Firewall(
                         hostname=p.hostname,
+                        port=p.port,
                         api_username=p._api_username,
                         api_password=p._api_password,
                         api_key=p._api_key,
@@ -1459,6 +1460,7 @@ class PanObject(object):
                 elif isinstance(p, Panorama):
                     new_obj = Panorama(
                         hostname=p.hostname,
+                        port=p.port,
                         api_username=p._api_username,
                         api_password=p._api_password,
                         api_key=p._api_key,


### PR DESCRIPTION
Inherit port number when set reference in refresh mode.

## Description
When device port number is not 443, set reference in refresh mode will fail without this change.

## Motivation and Context
Considering device is deployed under the NAPT, possibly device port number is not 443.

## How Has This Been Tested?
- python setup.py test
- tox
- deploy device under the NAPT and run following simple script:
```
import pandevice.firewall
import pandevice.network

fw = pandevice.firewall.Firewall('hostname', 'admin', 'password', port=14443)
eth = pandevice.network.EthernetInterface('ethernet1/1')
fw.add(eth)
eth.refresh()
eth.set_vsys('vsys1', refresh=True)
```

## Screenshots (if appropriate)
N/A

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
