### PR TITLE
Add panorama-server xpath for PAN-OS 9.1.0

### DIFF
--- a/pandevice/device.py
+++ b/pandevice/device.py
@@ -304,8 +304,14 @@ class SystemSettings(VersionedPanObject):
             'timezone', path='timezone'))
         params.append(VersionedParamPath(
             'panorama', path='panorama-server'))
+        params[-1].add_profile(
+            '9.1.0',
+            path='panorama/local-panorama/panorama-server')
         params.append(VersionedParamPath(
             'panorama2', path='panorama-server-2'))
+        params[-1].add_profile(
+            '9.1.0',
+            path='panorama/local-panorama/panorama-server-2')
         params.append(VersionedParamPath(
             'login_banner', path='login-banner'))
         params.append(VersionedParamPath(


### PR DESCRIPTION
New xpaths to configure Panorama servers in PAN-OS 9.1

## Description

Since PAN-OS 9.1, xpaths to configure Panorama servers have been modified.

## Motivation and Context

In PAN-OS 9.1, xpaths are:
- Server 1 = `/config/devices/entry[@name='...']/deviceconfig/system/panorama/local-panorama/panorama-server`
- Server 2 = `/config/devices/entry[@name='...']/deviceconfig/system/panorama/local-panorama/panorama-server-2`

Below PAN-OS 9.1, xpaths are:
- Server 1 = `/config/devices/entry[@name='...']/deviceconfig/system/panorama-server`
- Server 2 = `/config/devices/entry[@name='...']/deviceconfig/system/panorama-server-2`

## How Has This Been Tested?

```
$ flake8 pandevice tests
$ python setup.py test
$ tox
```
Then by using `panos_mgtconfig` Ansible module.

## Screenshots (if appropriate)

N/A

## Types of changes

- Bug fix (non-breaking change which fixes an issue) : #196 

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
