### PR TITLE
Adding a device reboot message after an upgrade

### DIFF
--- a/pandevice/updater.py
+++ b/pandevice/updater.py
@@ -125,6 +125,7 @@ class SoftwareUpdater(Updater):
             version = PanOSVersion(version)
         self.download_install(version, load_config, sync=True)
         # Reboot the device
+        self._logger.info("Device %s is rebooting after upgrading to version  %s. This will take a while." % (self.pandevice.id, version))
         self.pandevice.restart()
         if sync:
             new_version = self.pandevice.syncreboot()


### PR DESCRIPTION
This command adds a device reboot message after performing a device upgrade

<!--- Provide a general summary of your changes in the Title above -->

## Description
During a device upgrade, there are no messages when the device is rebooting after an upgrade, this line adds a message post the upgrade process and before the device is going down for reboot.

<!--- Describe your changes in detail -->

## Motivation and Context

There is not enough feedback from the script when a device is rebooting, especially after an upgrade, in which case, the reboot process might take some time.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested on my home PA-220
Tested on a local VM

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here -->

## Types of changes

<!--- What types of changes does your code introduce? -->

Adding a reboot message.

<!--- Remove any that don't apply: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
