### PR TITLE
support pretty element string output

### DIFF
--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -28,6 +28,7 @@ import re
 import sys
 import time
 import xml.etree.ElementTree as ET
+import xml.dom.minidom as minidom
 
 import pan.commit
 import pan.xapi
@@ -477,13 +478,20 @@ class PanObject(object):
 
         return root
 
-    def element_str(self):
+    def element_str(self, pretty_print=False):
         """The XML representation of this PanObject and all its children.
+
+        Args:
+            pretty_print (bool): Return the resulting string pretty_printed with indentation.
 
         Returns:
             str: XML form of this object and its children
 
         """
+        if pretty_print:
+            raw = ET.tostring(self.element, encoding="utf-8")
+            parsed = minidom.parseString(raw)
+            return parsed.toprettyxml(indent="\t", encoding="utf-8")
         return ET.tostring(self.element(), encoding="utf-8")
 
     def _root_element(self):
@@ -2605,10 +2613,6 @@ class VersionedPanObject(PanObject):
         # Save results from the settings dict
         for param in params:
             param.value = settings.get(param.name)
-
-    def element_str(self):
-        """The XML form of this object (and its children) as a string."""
-        return ET.tostring(self.element(), encoding="utf-8")
 
     def __getattr__(self, name):
         params = super(VersionedPanObject, self).__getattribute__("_params")

--- a/pandevice/base.py
+++ b/pandevice/base.py
@@ -489,7 +489,7 @@ class PanObject(object):
 
         """
         if pretty_print:
-            raw = ET.tostring(self.element, encoding="utf-8")
+            raw = ET.tostring(self.element(), encoding="utf-8")
             parsed = minidom.parseString(raw)
             return parsed.toprettyxml(indent="\t", encoding="utf-8")
         return ET.tostring(self.element(), encoding="utf-8")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -397,6 +397,31 @@ class TestElementStr_7_0(unittest.TestCase):
         o_str = o.element_str()
         self.assertEqual(expected, o_str)
 
+    # 6) pretty_print
+    def test_element_str_pretty(self):
+        expected = b"".join(
+            [
+                b'<?xml version="1.0" encoding="utf-8"?>\n',
+                b'<entry name="webserver">\n',
+                b'	<ip-netmask>192.168.1.100</ip-netmask>\n',
+                b'	<description>Intranet web server</description>\n',
+                b'	<tag>\n',
+                b'		<member>https</member>\n',
+                b'		<member>http</member>\n',
+                b'	</tag>\n',
+                b'</entry>\n',
+            ]
+        )
+        o = pandevice.objects.AddressObject(
+            "webserver",
+            "192.168.1.100",
+            description="Intranet web server",
+            tag=["https", "http"],
+        )
+
+        o_str = o.element_str(pretty_print=True)
+        self.assertEqual(expected, o_str)
+
 
 class TestXpaths_7_0(unittest.TestCase):
     """


### PR DESCRIPTION
also drop the element_str function of VersionPanObject since PanObject
already implemented the same function and it is inherited

<!--- Provide a general summary of your changes in the Title above -->

## Description

This allows to use the element_str function to return pretty printed xml. The default is unchanged.

There were 2 ways to introduce this:
   - Use lxml.etree which natively supports this
   - Reparse the ElementTree string representation

I chose the latter because it is less intrusive in the codebase, even though it is less efficient. Note I also implemented a [migration to lxml](https://github.com/fredericve/pandevice/tree/lxml).

## Motivation and Context

I'm implementing diff support in the ansible-pan project. Using pretty print is essential in showing an easily readable diff.

## How Has This Been Tested?

The test suite still runs fine with ```make test```

## Types of changes

<!--- What types of changes does your code introduce? -->

<!--- Remove any that don't apply: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.

