### PR TITLE
Add support for Regions

### DIFF
--- a/pandevice/device.py
+++ b/pandevice/device.py
@@ -126,6 +126,7 @@ class Vsys(VersionedPanObject):
         "objects.CustomUrlCategory",
         "objects.LogForwardingProfile",
         "objects.DynamicUserGroup",
+        "objects.Region",
         "policies.Rulebase",
         "network.EthernetInterface",
         "network.AggregateInterface",

--- a/pandevice/firewall.py
+++ b/pandevice/firewall.py
@@ -80,6 +80,7 @@ class Firewall(PanDevice):
         "objects.CustomUrlCategory",
         "objects.LogForwardingProfile",
         "objects.DynamicUserGroup",
+        "objects.Region",
         "policies.Rulebase",
         "network.EthernetInterface",
         "network.AggregateInterface",

--- a/pandevice/objects.py
+++ b/pandevice/objects.py
@@ -1011,3 +1011,35 @@ class ScheduleObject(VersionedPanObject):
         )
 
         self._params = tuple(params)
+
+
+class Region(VersionedPanObject):
+    """Region.
+
+    Args:
+        name (str): Name of the region
+        address (list): List of IP networks
+        latitude (float): Latitude of the region
+        longitude (float): Longitude of the region
+
+    """
+
+    ROOT = Root.VSYS
+    SUFFIX = ENTRY
+
+    def _setup(self):
+        # xpaths
+        self._xpaths.add_profile(value="/region")
+
+        # params
+        params = []
+
+        params.append(
+            VersionedParamPath("address", path="address", vartype="member")
+        )
+        params.append(VersionedParamPath("latitude", path="geo-location/latitude", vartype="float"))
+        params.append(VersionedParamPath("longitude", path="geo-location/longitude", vartype="float"))
+
+        self._params = tuple(params)
+
+

--- a/pandevice/panorama.py
+++ b/pandevice/panorama.py
@@ -65,6 +65,7 @@ class DeviceGroup(VersionedPanObject):
         "objects.SecurityProfileGroup",
         "objects.CustomUrlCategory",
         "objects.LogForwardingProfile",
+        "objects.Region",
         "policies.PreRulebase",
         "policies.PostRulebase",
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support for the Region object.

        name (str): Name of the region
        address (list): List of IP networks
        latitude (float): Latitude of the region
        longitude (float): Longitude of the region

## Motivation and Context

I needed to manipulate the regions in my firewall so added this pretty trivial object.

## How Has This Been Tested?

Tested against Panorama 9.0.3-h3

## Screenshots (if appropriate)

<!--- Drag any screenshots here -->

## Types of changes

<!--- What types of changes does your code introduce? -->

<!--- Remove any that don't apply: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly. (automatic)
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
