### PR TITLE
fix for target_version.minor in update

### DIFF
--- a/pandevice/updater.py
+++ b/pandevice/updater.py
@@ -307,7 +307,7 @@ class SoftwareUpdater(Updater):
         # eg. 6.0.2 -> 6.0.3
         if (
             current_version.major == target_version.major
-            and current_version.minor == current_version.minor
+            and current_version.minor == target_version.minor
         ):
             return True
 


### PR DESCRIPTION
Fix typo in comparison for _direct_upgrade_possible() function in updater.py

## Description

Fix typo

## Motivation and Context

Noticed when trying to use updater.py to upgrade from 9.0.5.xfr -> 9.1.2

#215 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)


## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
