### PR TITLE
feat: Add support for wildcard address objects

### DIFF
--- a/pandevice/objects.py
+++ b/pandevice/objects.py
@@ -40,6 +40,7 @@ class AddressObject(VersionedPanObject):
         type (str): Type of address:
                 * ip-netmask (default)
                 * ip-range
+                * ip-wildcard (added in PAN-OS 9.0)
                 * fqdn
         description (str): Description of this object
         tag (list): Administrative tags
@@ -61,7 +62,7 @@ class AddressObject(VersionedPanObject):
             VersionedParamPath(
                 "type",
                 default="ip-netmask",
-                values=["ip-netmask", "ip-range", "fqdn"],
+                values=["ip-netmask", "ip-range", "ip-wildcard", "fqdn"],
                 path="{type}",
             )
         )


### PR DESCRIPTION
## Description

Added ip-wildcard as a type in the AddressObject PanObject

Closes #226 

I chose not to use a version profile for this parameter because the user will get an error on pre-9.0 versions either way. For example, there's no reason to omit the ip-wildcard on 8.1 because that AddressObject would be invalid anyway.

## Motivation and Context

Support new feature in PAN-OS 9.0

## How Has This Been Tested?

Tested against PA-220

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
