### PR TITLE
removed vartype=int from tag-allowed in network.py

### DIFF
--- a/pandevice/network.py
+++ b/pandevice/network.py
@@ -637,7 +637,7 @@ class VirtualWire(VsysOperations):
         # params
         params = []
 
-        params.append(VersionedParamPath("tag", path="tag-allowed", vartype="int"))
+        params.append(VersionedParamPath("tag", path="tag-allowed"))
         params.append(VersionedParamPath("interface1", path="interface1"))
         params.append(VersionedParamPath("interface2", path="interface2"))
         params.append(


### PR DESCRIPTION
In network.py I removed the vartype='int' from the VersionedParamPath for the vwire 'tag-allowed' parameter.

## Description

In network.py, I removed the vartype='int' from the VersionedParamPath for the vwire 'tag-allowed' parameter. I did this because integer ranges such as 1-5 are also valid inputs

## Motivation and Context

A few of our templates in Panorama had vwires with tag-allowed fields set with integer ranges which caused errors when pandevice tried to parse

## How Has This Been Tested?

I have now successfully parsed the templates in multiple environments

## Screenshots (if appropriate)

<!--- Drag any screenshots here -->

## Types of changes

<!--- What types of changes does your code introduce? -->

allows non-integer values to parse successfully in the vwire tag-allowed field, specifically integer ranges such as '1-5'

<!--- Remove any that don't apply: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
